### PR TITLE
Fix default backend URL for frontend connections

### DIFF
--- a/codespace/frontend/src/setup.js
+++ b/codespace/frontend/src/setup.js
@@ -9,5 +9,9 @@ if (typeof process.env.CUSTOM_VARIABLE === 'undefined') {
   process.env.CUSTOM_VARIABLE = 'your_value'; // Set your custom environment variable
 }
 
+if (typeof process.env.REACT_APP_BACKEND_URL === 'undefined') {
+  process.env.REACT_APP_BACKEND_URL = 'http://localhost:6909';
+}
+
 window.process = process; // Make 'process' available in the global scope
 


### PR DESCRIPTION
## Summary
- Default frontend `REACT_APP_BACKEND_URL` to `http://localhost:6909`

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68991537a4e883289774de1d9daaad35