### PR TITLE
Add Docker Compose development environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+# Server Dockerfile
+FROM node:18
+WORKDIR /app
+COPY codespace/server/package*.json ./
+RUN npm install
+COPY codespace/server/ .
+EXPOSE 5000
+CMD ["node", "app.js"]

--- a/README.md
+++ b/README.md
@@ -42,3 +42,19 @@ All protected routes expect the JWT in the `Authorization: Bearer <token>` heade
 
 - `Login` and `Signup` pages interact with the new authentication endpoints.
 - `Navbar` shows different options based on the logged-in user's role. Admins see links to create problems while normal users see links to solve problems.
+
+## Docker setup
+
+The entire project can be run using Docker Compose. Ensure Docker and
+Docker Compose are installed, then run:
+
+```
+docker-compose up --build
+```
+
+This builds and starts the server, client, judge, and MongoDB services. The
+React client is available at [http://localhost:3000](http://localhost:3000)
+and the Node.js server at [http://localhost:5000](http://localhost:5000).
+Source directories are mounted into the containers for hot reloading during
+development, and environment variables such as the Mongo connection string
+and JWT secret are configured via `docker-compose.yml`.

--- a/codespace/frontend/Dockerfile
+++ b/codespace/frontend/Dockerfile
@@ -1,0 +1,8 @@
+# Frontend Dockerfile
+FROM node:18
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/codespace/server/app.js
+++ b/codespace/server/app.js
@@ -167,6 +167,7 @@ app.use((req, res, next) => {
     });
   });
 
-server.listen(6909, () => {
-    console.log(`server listening`);
+const PORT = process.env.PORT || 6909;
+server.listen(PORT, () => {
+    console.log(`server listening on ${PORT}`);
 })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3.8'
+services:
+  mongo:
+    image: mongo:6
+    volumes:
+      - mongo_data:/data/db
+
+  server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - MONGODB_URI=mongodb://mongo:27017/judge
+      - JWT_SECRET=changeme
+      - PORT=5000
+    volumes:
+      - ./codespace/server:/app
+      - server_node_modules:/app/node_modules
+    ports:
+      - "5000:5000"
+    depends_on:
+      - mongo
+
+  client:
+    build: ./codespace/frontend
+    environment:
+      - REACT_APP_SERVER_URL=http://server:5000
+    volumes:
+      - ./codespace/frontend:/app
+      - client_node_modules:/app/node_modules
+    ports:
+      - "3000:3000"
+    depends_on:
+      - server
+
+  judge:
+    build: ./codespace/Docker
+    depends_on:
+      - server
+
+volumes:
+  mongo_data:
+  server_node_modules:
+  client_node_modules:


### PR DESCRIPTION
## Summary
- containerize server with root Dockerfile and expose configurable port
- add frontend Dockerfile and docker-compose stack for server, client, judge, and MongoDB with hot-reload volumes
- document Docker-based workflow

## Testing
- `npm test` (server) *(fails: Missing script "test")*
- `npm test -- --watchAll=false` (frontend) *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68992df1ad688328acadc8baac8f2ff2