### PR TITLE
Add Redis service to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ services:
   mongo:
     image: mongo:6
     volumes: [mongo_data:/data/db]
+  redis:
+    image: redis:7
+    ports: [6379:6379]
   server:
     build:
       context: .
@@ -12,11 +15,14 @@ services:
       - MONGODB_URI=mongodb://mongo:27017/judge
       - JWT_SECRET=changeme
       - PORT=27017
+      - REDIS_URL=redis://redis:6379
+      - REDIS_HOST=redis
+      - REDIS_PORT=6379
     volumes:
       - ./codespace/server:/app
       - server_node_modules:/app/node_modules
     ports: [27017:27017]
-    depends_on: [mongo]
+    depends_on: [mongo, redis]
   client:
     build: ./codespace/frontend
     environment: [REACT_APP_SERVER_URL=http://server:27017]


### PR DESCRIPTION
## Summary
- add redis container running on port 6379
- configure server to connect to redis

## Testing
- `docker-compose config` *(fails: command not found)*
- `npm test` *(fails: Could not read package.json)*
- `cd codespace/server && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689a1cd72ef08328a4637645b4da19bb