### PR TITLE
Add landing and auth pages for new entry flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,21 @@ node server/scripts/migrateFromS3.js <s3-bucket-name>
 ```
 
 This script requires the AWS CLI to be installed and configured.
+
+## Frontend entry flow
+
+The React frontend now provides a landing page and authentication funnel:
+
+- `http://localhost:3000/` – Welcome page with a hero banner and a button to log in or sign up.
+- `/login` – Login form that posts to `/api/auth/login` and stores the returned JWT. Successful logins redirect to `/join`.
+- `/signup` – Signup form for new users posting to `/api/auth/register`. After registration the user is redirected to `/login`.
+
+To run the frontend locally:
+
+```
+cd codespace/frontend
+npm install
+npm start
+```
+
+Then open [http://localhost:3000/](http://localhost:3000/) in your browser.

--- a/codespace/frontend/src/App.js
+++ b/codespace/frontend/src/App.js
@@ -1,22 +1,25 @@
-// import io from 'socket.io-client';
-import './App.css'
+import './App.css';
+import WelcomePage from './components/WelcomePage';
+import LoginPage from './components/LoginPage';
+import SignupPage from './components/SignupPage';
 import JoinRoom from './Components/JoinRoom';
-import { Route,Routes, BrowserRouter } from 'react-router-dom';
+import { Route, Routes, BrowserRouter } from 'react-router-dom';
 import CreateNewRoom from './Components/CreateNewRoom';
 import Room from './Components/Room';
 import GetUsername from './Components/GetUsername';
 
-// const socket = io("localhost:6909/",{transports: ['websocket']});
-
 function App(){
-  console.log(process.env)
+  console.log(process.env);
   return (
     <BrowserRouter>
       <Routes>
-          <Route path="/join" element={<JoinRoom />} />
-          <Route path="/create" element={<CreateNewRoom />} />
-          <Route path="/room/:roomid/:userid" element={<Room />} />
-          <Route path="/room/:roomid/" element={<GetUsername />} />
+        <Route path="/" element={<WelcomePage />} />
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/signup" element={<SignupPage />} />
+        <Route path="/join" element={<JoinRoom />} />
+        <Route path="/create" element={<CreateNewRoom />} />
+        <Route path="/room/:roomid/:userid" element={<Room />} />
+        <Route path="/room/:roomid/" element={<GetUsername />} />
       </Routes>
     </BrowserRouter>
   );

--- a/codespace/frontend/src/AuthPage.css
+++ b/codespace/frontend/src/AuthPage.css
@@ -1,0 +1,60 @@
+.auth-background {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
+  font-family: 'Segoe UI', sans-serif;
+}
+
+.auth-card {
+  background: #ffffff;
+  padding: 2rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 400px;
+}
+
+.auth-card h2 {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.auth-card form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.auth-card input {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+}
+
+.auth-card button {
+  margin-top: 0.5rem;
+  padding: 0.75rem;
+  background-color: #1976d2;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.auth-card button:hover {
+  background-color: #115293;
+}
+
+.error {
+  color: red;
+  text-align: center;
+  margin-bottom: 0.5rem;
+}
+
+.switch-link {
+  text-align: center;
+  margin-top: 1rem;
+}

--- a/codespace/frontend/src/LoginPage.css
+++ b/codespace/frontend/src/LoginPage.css
@@ -1,0 +1,1 @@
+@import './AuthPage.css';

--- a/codespace/frontend/src/SignupPage.css
+++ b/codespace/frontend/src/SignupPage.css
@@ -1,0 +1,1 @@
+@import './AuthPage.css';

--- a/codespace/frontend/src/WelcomePage.css
+++ b/codespace/frontend/src/WelcomePage.css
@@ -1,0 +1,34 @@
+.welcome-background {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
+  font-family: 'Segoe UI', sans-serif;
+}
+
+.welcome-hero {
+  text-align: center;
+  color: #333;
+  padding: 2rem;
+}
+
+.welcome-title {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+
+.welcome-button {
+  margin-top: 2rem;
+  padding: 0.75rem 2rem;
+  background-color: #1976d2;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 1.1rem;
+  cursor: pointer;
+}
+
+.welcome-button:hover {
+  background-color: #115293;
+}

--- a/codespace/frontend/src/components/LoginPage.js
+++ b/codespace/frontend/src/components/LoginPage.js
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import '../LoginPage.css';
+
+function LoginPage() {
+  const [identifier, setIdentifier] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ identifier, password }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.message || 'Invalid credentials');
+        return;
+      }
+      localStorage.setItem('token', data.token);
+      navigate('/join');
+    } catch (err) {
+      setError('Login failed');
+    }
+  };
+
+  return (
+    <div className="auth-background">
+      <div className="auth-card">
+        <h2>Log In</h2>
+        {error && <p className="error">{error}</p>}
+        <form onSubmit={handleSubmit}>
+          <input
+            type="text"
+            placeholder="Email or Username"
+            value={identifier}
+            onChange={(e) => setIdentifier(e.target.value)}
+            required
+          />
+          <input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+          <button type="submit">Log In</button>
+        </form>
+        <p className="switch-link">
+          New here? <Link to="/signup">Create an account</Link>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default LoginPage;

--- a/codespace/frontend/src/components/SignupPage.js
+++ b/codespace/frontend/src/components/SignupPage.js
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import '../SignupPage.css';
+
+function SignupPage() {
+  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (password !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+    setError('');
+    try {
+      const res = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, email, password }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.message || 'Signup failed');
+        return;
+      }
+      localStorage.setItem('token', data.token);
+      navigate('/login');
+    } catch (err) {
+      setError('Signup failed');
+    }
+  };
+
+  return (
+    <div className="auth-background">
+      <div className="auth-card">
+        <h2>Create Account</h2>
+        {error && <p className="error">{error}</p>}
+        <form onSubmit={handleSubmit}>
+          <input
+            type="text"
+            placeholder="Username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            required
+          />
+          <input
+            type="email"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+          <input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+          <input
+            type="password"
+            placeholder="Confirm Password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            required
+          />
+          <button type="submit">Sign Up</button>
+        </form>
+        <p className="switch-link">
+          Already have an account? <Link to="/login">Log in</Link>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default SignupPage;

--- a/codespace/frontend/src/components/WelcomePage.js
+++ b/codespace/frontend/src/components/WelcomePage.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import '../WelcomePage.css';
+
+function WelcomePage() {
+  const navigate = useNavigate();
+  return (
+    <div className="welcome-background">
+      <div className="welcome-hero">
+        <h1 className="welcome-title">USACO Training Portal</h1>
+        <p className="welcome-tagline">Practice, learn, and compete with friends</p>
+        <button className="welcome-button" onClick={() => navigate('/login')}>
+          Log in / Sign up
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default WelcomePage;


### PR DESCRIPTION
## Summary
- Add USACO-style welcome, login, and signup React components with shared styling
- Wire new components into router and document entry flow
- Save JWTs from auth APIs and navigate on success

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689b6d131b308328a3f4c39d127e37cc