### PR TITLE
Add server authentication routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Create a `.env` file inside the `server/` folder with:
 ```
 MONGODB_URI=<your mongodb uri>
 TEST_DATA_DIR=./test-data
+JWT_SECRET=<your jwt secret>
 ```
 
 `TEST_DATA_DIR` controls where test files are saved and loaded from.

--- a/codespace/server/app.js
+++ b/codespace/server/app.js
@@ -6,6 +6,7 @@ var bodyParser = require('body-parser');
 const test = require("./routes/test")
 const submit = require("./routes/submit")
 const api1 = require("./routes/api")
+const auth = require("./routes/auth")
 const rateLimit = require('express-rate-limit');
 
 const app = express();
@@ -29,6 +30,7 @@ const io = new Server(server); // this shit creates a separate websocket server 
 app.use(express.json({limit: '50mb'}));
 app.use(express.json({limit: '50mb' , extended: true}));
 
+app.use('/api/auth',auth)
 app.use('/api',api1)
 app.use('/test',test)
 app.use('/submit',submit)

--- a/codespace/server/model/userModel.js
+++ b/codespace/server/model/userModel.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const userSchema = new mongoose.Schema({
+  username: { type: String, required: true, unique: true },
+  email: { type: String, required: true, unique: true },
+  password: { type: String, required: true }
+});
+
+module.exports = mongoose.model('User', userSchema);

--- a/codespace/server/package.json
+++ b/codespace/server/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "bcryptjs": "^2.4.3",
     "body-parser": "^1.20.2",
     "bullmq": "^5.8.3",
     "cors": "^2.8.5",
@@ -18,6 +19,7 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-rate-limit": "^7.2.0",
+    "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.1.0",
     "node-fetch": "^2.7.0",
     "redis": "^4.6.13",

--- a/codespace/server/routes/auth.js
+++ b/codespace/server/routes/auth.js
@@ -1,0 +1,51 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const User = require('../model/userModel');
+require('dotenv').config();
+
+const router = express.Router();
+const url = process.env.MONGODB_URI;
+
+mongoose.connect(url);
+
+router.post('/register', async (req, res) => {
+  const { username, email, password } = req.body;
+  try {
+    const existing = await User.findOne({ $or: [{ username }, { email }] });
+    if (existing) {
+      return res.status(400).json({ message: 'User already exists' });
+    }
+    const hashed = await bcrypt.hash(password, 10);
+    const user = new User({ username, email, password: hashed });
+    await user.save();
+    res.json({ message: 'User created' });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.post('/login', async (req, res) => {
+  const { identifier, password } = req.body;
+  try {
+    const user = await User.findOne({ $or: [{ username: identifier }, { email: identifier }] });
+    if (!user) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+    const match = await bcrypt.compare(password, user.password);
+    if (!match) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+    const token = jwt.sign(
+      { id: user._id, username: user.username },
+      process.env.JWT_SECRET,
+      { expiresIn: '1h' }
+    );
+    res.json({ token });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add JWT-based user registration and login endpoints
- store users in MongoDB with hashed passwords
- document JWT_SECRET environment variable

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689b768da1948328a90bf0bf40754160