### PR TITLE
refactor: use backend base URL for auth requests

### DIFF
--- a/codespace/frontend/src/pages/LoginPage.js
+++ b/codespace/frontend/src/pages/LoginPage.js
@@ -12,7 +12,7 @@ function LoginPage() {
     e.preventDefault();
     setError('');
     try {
-      const res = await fetch('/api/auth/login', {
+      const res = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/auth/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ identifier, password }),

--- a/codespace/frontend/src/pages/SignupPage.js
+++ b/codespace/frontend/src/pages/SignupPage.js
@@ -18,7 +18,7 @@ function SignupPage() {
     }
     setError('');
     try {
-      const res = await fetch('/api/auth/register', {
+      const res = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/auth/register`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, email, password }),


### PR DESCRIPTION
## Summary
- reference backend API via `REACT_APP_BACKEND_URL` in login and signup pages

## Testing
- `CI=true npm test -- --passWithNoTests` (frontend)
- `npm test` (backend, missing script)


------
https://chatgpt.com/codex/tasks/task_e_689a1fced5b48328bd54d274107a6f1d