### PR TITLE
feat: centralize room flow and add contest navigation

### DIFF
--- a/codespace/frontend/src/App.js
+++ b/codespace/frontend/src/App.js
@@ -2,11 +2,11 @@ import './styles/App.css';
 import HomePage from './pages/HomePage';
 import LoginPage from './pages/LoginPage';
 import SignupPage from './pages/SignupPage';
-import JoinRoom from './components/JoinRoom';
 import { Route, Routes, BrowserRouter } from 'react-router-dom';
-import CreateNewRoom from './components/CreateNewRoom';
 import Room from './components/Room';
 import GetUsername from './components/GetUsername';
+import ContestPage from './pages/ContestPage';
+import RoomsPage from './pages/RoomsPage';
 
 function App(){
   console.log(process.env);
@@ -16,10 +16,10 @@ function App(){
         <Route path="/" element={<HomePage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/signup" element={<SignupPage />} />
-        <Route path="/join" element={<JoinRoom />} />
-        <Route path="/create" element={<CreateNewRoom />} />
-        <Route path="/room/:roomid/:userid" element={<Room />} />
-        <Route path="/room/:roomid/" element={<GetUsername />} />
+        <Route path="/contest" element={<ContestPage />} />
+        <Route path="/rooms" element={<RoomsPage />} />
+        <Route path="/rooms/:roomid/:userid" element={<Room />} />
+        <Route path="/rooms/:roomid" element={<GetUsername />} />
       </Routes>
     </BrowserRouter>
   );

--- a/codespace/frontend/src/components/CreateNewRoom.js
+++ b/codespace/frontend/src/components/CreateNewRoom.js
@@ -18,12 +18,12 @@ export default function CreateNewRoom() {
     const handleSubmit = (e) => {
       e.preventDefault();
       socket.emit('join-room',{username:username,roomid:roomid});
-      navigate(`/room/${roomid}`);
+      navigate(`/rooms/${roomid}`);
     };
 
-    return (
-      <div>
-        <h2>Create Room</h2>
+      return (
+        <div className="auth-card">
+          <h2>Create Room</h2>
         <form onSubmit={handleSubmit}>
           <div>
             <label htmlFor="username">Username</label>
@@ -34,7 +34,7 @@ export default function CreateNewRoom() {
               onChange={handleUsernameChange}
             />
           </div>
-          <button type="submit">Login</button>
+          <button type="submit">Create</button>
         </form>
       </div>
     );

--- a/codespace/frontend/src/components/GetUsername.js
+++ b/codespace/frontend/src/components/GetUsername.js
@@ -18,7 +18,7 @@ export default function GetUsername() {
 
     function handleSubmit(e){
         e.preventDefault();
-        navigate(`/room/${roomid}/${username}`);
+        navigate(`/rooms/${roomid}/${username}`);
     }
 
     return (

--- a/codespace/frontend/src/components/JoinRoom.js
+++ b/codespace/frontend/src/components/JoinRoom.js
@@ -21,12 +21,12 @@ export default function JoinRoom() {
     const handleSubmit = (e) => {
       e.preventDefault();
       socket.emit('join-room',{username:username,roomid:roomid});
-      navigate(`/room/${roomid}`);
+      navigate(`/rooms/${roomid}`);
     };
   
-    return (
-      <div>
-        <h2>Join Room</h2>
+      return (
+        <div className="auth-card">
+          <h2>Join Room</h2>
         <form onSubmit={handleSubmit}>
           <div>
             <label htmlFor="username">Username</label>
@@ -47,7 +47,7 @@ export default function JoinRoom() {
             />
           </div>
           <br />
-        <button type="submit">Login</button>
+        <button type="submit">Join</button>
         </form>
         {/* <button>Hi</button> */}
       </div>

--- a/codespace/frontend/src/components/NavBar.js
+++ b/codespace/frontend/src/components/NavBar.js
@@ -13,12 +13,9 @@ function NavBar() {
         </Link>
       </div>
       <ul className="navbar-links">
-        <li><Link to="/problems">Problems</Link></li>
-        <li><Link to="/resources">Resources</Link></li>
-        <li><Link to="/sections">Sections</Link></li>
-        <li><Link to="/contact">Contact Us</Link></li>
+        <li><Link to="/contest">Contest</Link></li>
+        <li><Link to="/rooms">Rooms</Link></li>
         <li><Link to="/login">Login</Link></li>
-        <li><Link to="/settings">Settings</Link></li>
       </ul>
     </nav>
   );

--- a/codespace/frontend/src/pages/ContestPage.js
+++ b/codespace/frontend/src/pages/ContestPage.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import NavBar from '../components/NavBar';
+
+function ContestPage() {
+  return (
+    <div>
+      <NavBar />
+      <h2 style={{ textAlign: 'center', marginTop: '2rem' }}>Contest Coming Soon</h2>
+    </div>
+  );
+}
+
+export default ContestPage;

--- a/codespace/frontend/src/pages/LoginPage.js
+++ b/codespace/frontend/src/pages/LoginPage.js
@@ -23,7 +23,7 @@ function LoginPage() {
         return;
       }
       localStorage.setItem('token', data.token);
-      navigate('/join');
+      navigate('/');
     } catch (err) {
       setError('Login failed');
     }

--- a/codespace/frontend/src/pages/RoomsPage.js
+++ b/codespace/frontend/src/pages/RoomsPage.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import NavBar from '../components/NavBar';
+import JoinRoom from '../components/JoinRoom';
+import CreateNewRoom from '../components/CreateNewRoom';
+import '../styles/RoomsPage.css';
+
+function RoomsPage() {
+  return (
+    <div className="rooms-container">
+      <NavBar />
+      <div className="rooms-content">
+        <JoinRoom />
+        <CreateNewRoom />
+      </div>
+    </div>
+  );
+}
+
+export default RoomsPage;

--- a/codespace/frontend/src/styles/RoomsPage.css
+++ b/codespace/frontend/src/styles/RoomsPage.css
@@ -1,0 +1,17 @@
+@import './AuthPage.css';
+
+.rooms-container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.rooms-content {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 2rem;
+  background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
+  padding: 2rem;
+}


### PR DESCRIPTION
## Summary
- Add navbar links for Contest and Rooms and redirect logins back to the home page
- Introduce Rooms page grouping room creation and join flows with shared styling
- Route room features under `/rooms` and add a placeholder Contest page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d1ee5969c83289ea803d31fe264db