### PR TITLE
feat: add rooms with public and private options

### DIFF
--- a/codespace/frontend/src/App.js
+++ b/codespace/frontend/src/App.js
@@ -7,6 +7,10 @@ import Room from './components/Room';
 import GetUsername from './components/GetUsername';
 import ContestPage from './pages/ContestPage';
 import RoomsPage from './pages/RoomsPage';
+import ProblemsPage from './pages/ProblemsPage';
+import ResourcesPage from './pages/ResourcesPage';
+import SectionsPage from './pages/SectionsPage';
+import ContactPage from './pages/ContactPage';
 
 function App(){
   console.log(process.env);
@@ -16,8 +20,12 @@ function App(){
         <Route path="/" element={<HomePage />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/signup" element={<SignupPage />} />
+        <Route path="/problems" element={<ProblemsPage />} />
+        <Route path="/resources" element={<ResourcesPage />} />
+        <Route path="/sections" element={<SectionsPage />} />
         <Route path="/contest" element={<ContestPage />} />
         <Route path="/rooms" element={<RoomsPage />} />
+        <Route path="/contact" element={<ContactPage />} />
         <Route path="/rooms/:roomid/:userid" element={<Room />} />
         <Route path="/rooms/:roomid" element={<GetUsername />} />
       </Routes>

--- a/codespace/frontend/src/components/CreateNewRoom.js
+++ b/codespace/frontend/src/components/CreateNewRoom.js
@@ -1,41 +1,80 @@
-import React, { useState } from 'react'
-import io from 'socket.io-client';
+import React, { useState } from 'react';
 import { v4 } from 'uuid';
 import { useNavigate } from 'react-router-dom';
-const socket = io(process.env.REACT_APP_BACKEND_URL,{transports: ['websocket']});
 
-const randomUuid = v4();
+export default function CreateNewRoom({ onBack }) {
+  const navigate = useNavigate();
+  const [isPrivate, setIsPrivate] = useState(false);
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState('');
+  const roomid = v4();
 
-export default function CreateNewRoom() {
-    const navigate = useNavigate();
-    const [username, setUsername] = useState('');
-    const [roomid] = useState(randomUuid);
-  
-    const handleUsernameChange = (e) => {
-      setUsername(e.target.value);
-    };
-  
-    const handleSubmit = (e) => {
-      e.preventDefault();
-      socket.emit('join-room',{username:username,roomid:roomid});
-      navigate(`/rooms/${roomid}`);
-    };
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (isPrivate && password !== confirmPassword) {
+      setError('Passwords do not match');
+      return;
+    }
+    try {
+      const res = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/rooms/create`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ roomid, isPrivate, password: isPrivate ? password : undefined }),
+      });
+      if (res.ok) {
+        navigate(`/rooms/${roomid}`);
+      } else {
+        const data = await res.json();
+        setError(data.message || 'Error creating room');
+      }
+    } catch (err) {
+      setError('Server error');
+    }
+  };
 
-      return (
-        <div className="auth-card">
-          <h2>Create Room</h2>
-        <form onSubmit={handleSubmit}>
-          <div>
-            <label htmlFor="username">Username</label>
-            <input
-              type="text"
-              id="username"
-              value={username}
-              onChange={handleUsernameChange}
-            />
-          </div>
-          <button type="submit">Create</button>
-        </form>
-      </div>
-    );
+  return (
+    <div className="auth-card">
+      <h2>Create Room</h2>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label>Room Type</label>
+          <select
+            value={isPrivate ? 'private' : 'public'}
+            onChange={(e) => setIsPrivate(e.target.value === 'private')}
+          >
+            <option value="public">Public</option>
+            <option value="private">Private</option>
+          </select>
+        </div>
+        {isPrivate && (
+          <>
+            <div>
+              <label htmlFor="password">Password</label>
+              <input
+                type="password"
+                id="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+              />
+            </div>
+            <div>
+              <label htmlFor="confirm">Confirm Password</label>
+              <input
+                type="password"
+                id="confirm"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+              />
+            </div>
+          </>
+        )}
+        {error && <p>{error}</p>}
+        <button type="submit">Create</button>
+      </form>
+      <p>
+        <button type="button" onClick={onBack}>Back to join</button>
+      </p>
+    </div>
+  );
 }

--- a/codespace/frontend/src/components/JoinRoom.js
+++ b/codespace/frontend/src/components/JoinRoom.js
@@ -1,55 +1,69 @@
-import React, { useState } from 'react'
-import io from 'socket.io-client';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-const socket = io(process.env.REACT_APP_BACKEND_URL,{transports: ['websocket']});
 
-export default function JoinRoom() {
-    const navigate = useNavigate();
-    const [username, setUsername] = useState('');
-    const [roomid, setRoomid] = useState('');
+export default function JoinRoom({ onCreateClick }) {
+  const navigate = useNavigate();
+  const [roomid, setRoomid] = useState('');
+  const [password, setPassword] = useState('');
+  const [needsPassword, setNeedsPassword] = useState(false);
+  const [error, setError] = useState('');
 
-    
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const body = { roomid };
+    if (needsPassword) body.password = password;
+    try {
+      const res = await fetch(`${process.env.REACT_APP_BACKEND_URL}/api/rooms/join`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json();
+      if (data.requiresPassword) {
+        setNeedsPassword(true);
+        setError('');
+      } else if (res.ok) {
+        navigate(`/rooms/${roomid}`);
+      } else {
+        setError(data.message || 'Error joining room');
+      }
+    } catch (err) {
+      setError('Server error');
+    }
+  };
 
-    const handleUsernameChange = (e) => {
-      setUsername(e.target.value);
-    };
-  
-    const handleRoomidChange = (e) => {
-      setRoomid(e.target.value);
-    };
-  
-    const handleSubmit = (e) => {
-      e.preventDefault();
-      socket.emit('join-room',{username:username,roomid:roomid});
-      navigate(`/rooms/${roomid}`);
-    };
-  
-      return (
-        <div className="auth-card">
-          <h2>Join Room</h2>
-        <form onSubmit={handleSubmit}>
+  return (
+    <div className="auth-card">
+      <h2>Join Room</h2>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label htmlFor="roomid">Room ID</label>
+          <input
+            type="text"
+            id="roomid"
+            value={roomid}
+            onChange={(e) => setRoomid(e.target.value)}
+          />
+        </div>
+        {needsPassword && (
           <div>
-            <label htmlFor="username">Username</label>
+            <label htmlFor="password">Password</label>
             <input
-              type="text"
-              id="username"
-              value={username}
-              onChange={handleUsernameChange}
+              type="password"
+              id="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
             />
           </div>
-          <div>
-            <label htmlFor="password">Room ID</label>
-            <input
-              type="text"
-              id="roomid"
-              value={roomid}
-              onChange={handleRoomidChange}
-            />
-          </div>
-          <br />
+        )}
+        {error && <p>{error}</p>}
+        <br />
         <button type="submit">Join</button>
-        </form>
-        {/* <button>Hi</button> */}
-      </div>
-    );
+      </form>
+      <p>
+        Don't want to join?{' '}
+        <button type="button" onClick={onCreateClick}>Create a room</button>
+      </p>
+    </div>
+  );
 }

--- a/codespace/frontend/src/components/NavBar.js
+++ b/codespace/frontend/src/components/NavBar.js
@@ -13,8 +13,12 @@ function NavBar() {
         </Link>
       </div>
       <ul className="navbar-links">
+        <li><Link to="/problems">Problems</Link></li>
+        <li><Link to="/resources">Resources</Link></li>
+        <li><Link to="/sections">Sections</Link></li>
         <li><Link to="/contest">Contest</Link></li>
         <li><Link to="/rooms">Rooms</Link></li>
+        <li><Link to="/contact">Contact Us</Link></li>
         <li><Link to="/login">Login</Link></li>
       </ul>
     </nav>

--- a/codespace/frontend/src/pages/ContactPage.js
+++ b/codespace/frontend/src/pages/ContactPage.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import NavBar from '../components/NavBar';
+
+function ContactPage() {
+  return (
+    <div>
+      <NavBar />
+      <h1>Contact Us</h1>
+    </div>
+  );
+}
+
+export default ContactPage;

--- a/codespace/frontend/src/pages/ProblemsPage.js
+++ b/codespace/frontend/src/pages/ProblemsPage.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import NavBar from '../components/NavBar';
+
+function ProblemsPage() {
+  return (
+    <div>
+      <NavBar />
+      <h1>Problems Page</h1>
+    </div>
+  );
+}
+
+export default ProblemsPage;

--- a/codespace/frontend/src/pages/ResourcesPage.js
+++ b/codespace/frontend/src/pages/ResourcesPage.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import NavBar from '../components/NavBar';
+
+function ResourcesPage() {
+  return (
+    <div>
+      <NavBar />
+      <h1>Resources Page</h1>
+    </div>
+  );
+}
+
+export default ResourcesPage;

--- a/codespace/frontend/src/pages/RoomsPage.js
+++ b/codespace/frontend/src/pages/RoomsPage.js
@@ -1,16 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
 import NavBar from '../components/NavBar';
 import JoinRoom from '../components/JoinRoom';
 import CreateNewRoom from '../components/CreateNewRoom';
 import '../styles/RoomsPage.css';
 
 function RoomsPage() {
+  const [creating, setCreating] = useState(false);
   return (
     <div className="rooms-container">
       <NavBar />
       <div className="rooms-content">
-        <JoinRoom />
-        <CreateNewRoom />
+        {creating ? (
+          <CreateNewRoom onBack={() => setCreating(false)} />
+        ) : (
+          <JoinRoom onCreateClick={() => setCreating(true)} />
+        )}
       </div>
     </div>
   );

--- a/codespace/frontend/src/pages/SectionsPage.js
+++ b/codespace/frontend/src/pages/SectionsPage.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import NavBar from '../components/NavBar';
+
+function SectionsPage() {
+  return (
+    <div>
+      <NavBar />
+      <h1>Sections Page</h1>
+    </div>
+  );
+}
+
+export default SectionsPage;

--- a/codespace/server/app.js
+++ b/codespace/server/app.js
@@ -7,6 +7,7 @@ const test = require("./routes/test")
 const submit = require("./routes/submit")
 const api1 = require("./routes/api")
 const auth = require("./routes/auth")
+const roomsRoute = require("./routes/rooms")
 const rateLimit = require('express-rate-limit');
 
 const app = express();
@@ -32,6 +33,7 @@ app.use(express.json({limit: '50mb' , extended: true}));
 
 app.use('/api/auth',auth)
 app.use('/api',api1)
+app.use('/api/rooms',roomsRoute)
 app.use('/test',test)
 app.use('/submit',submit)
 

--- a/codespace/server/model/roomModel.js
+++ b/codespace/server/model/roomModel.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const roomSchema = new mongoose.Schema({
+  roomid: { type: String, required: true, unique: true },
+  isPrivate: { type: Boolean, default: false },
+  password: { type: String },
+});
+
+module.exports = mongoose.model('Room', roomSchema);

--- a/codespace/server/routes/rooms.js
+++ b/codespace/server/routes/rooms.js
@@ -1,0 +1,47 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const Room = require('../model/roomModel');
+require('dotenv').config();
+
+const router = express.Router();
+const url = process.env.MONGODB_URI;
+
+mongoose.connect(url);
+
+router.post('/create', async (req, res) => {
+  const { roomid, isPrivate, password } = req.body;
+  try {
+    const existing = await Room.findOne({ roomid });
+    if (existing) {
+      return res.status(400).json({ message: 'Room already exists' });
+    }
+    const room = new Room({ roomid, isPrivate, password: isPrivate ? password : undefined });
+    await room.save();
+    res.json({ roomid });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.post('/join', async (req, res) => {
+  const { roomid, password } = req.body;
+  try {
+    const room = await Room.findOne({ roomid });
+    if (!room) {
+      return res.status(404).json({ message: 'Room not found' });
+    }
+    if (room.isPrivate) {
+      if (!password) {
+        return res.json({ requiresPassword: true });
+      }
+      if (room.password !== password) {
+        return res.status(401).json({ message: 'Invalid password' });
+      }
+    }
+    res.json({ roomid });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- expand navigation bar with pages for problems, resources, sections, and contact
- implement join/create room flow with public/private rooms and optional passwords
- add server-side room model and routes

## Testing
- `npm test --prefix codespace/frontend -- --watchAll=false --passWithNoTests`
- `node -e "const mongoose=require('./codespace/server/node_modules/mongoose');mongoose.connect('mongodb://localhost:27017/GraduationProject', {serverSelectionTimeoutMS:1000}).then(()=>{console.log('connected');process.exit(0);}).catch(err=>{console.error('connect error',err.message);process.exit(1);});"` *(fails: connect ECONNREFUSED ::1:27017, connect ECONNREFUSED 127.0.0.1:27017)*

------
https://chatgpt.com/codex/tasks/task_e_689d23f2ddf883289fd9053d32ddd152