### PR TITLE
Show profile dropdown after login

### DIFF
--- a/codespace/frontend/src/App.js
+++ b/codespace/frontend/src/App.js
@@ -11,6 +11,7 @@ import ProblemsPage from './pages/ProblemsPage';
 import ResourcesPage from './pages/ResourcesPage';
 import SectionsPage from './pages/SectionsPage';
 import ContactPage from './pages/ContactPage';
+import ProfilePage from './pages/ProfilePage';
 
 function App(){
   console.log(process.env);
@@ -26,6 +27,7 @@ function App(){
         <Route path="/contest" element={<ContestPage />} />
         <Route path="/rooms" element={<RoomsPage />} />
         <Route path="/contact" element={<ContactPage />} />
+        <Route path="/profile" element={<ProfilePage />} />
         <Route path="/rooms/:roomid/:userid" element={<Room />} />
         <Route path="/rooms/:roomid" element={<GetUsername />} />
       </Routes>

--- a/codespace/frontend/src/components/NavBar.js
+++ b/codespace/frontend/src/components/NavBar.js
@@ -1,9 +1,25 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import '../styles/NavBar.css';
 import logo from '../assets/images/logo.svg';
 
 function NavBar() {
+  const [loggedIn, setLoggedIn] = useState(false);
+  const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    setLoggedIn(!!token);
+  }, []);
+
+  const handleLogout = () => {
+    localStorage.removeItem('token');
+    setLoggedIn(false);
+    setOpen(false);
+    navigate('/login');
+  };
+
   return (
     <nav className="navbar">
       <div className="navbar-brand">
@@ -19,7 +35,20 @@ function NavBar() {
         <li><Link to="/contest">Contest</Link></li>
         <li><Link to="/rooms">Rooms</Link></li>
         <li><Link to="/contact">Contact Us</Link></li>
-        <li><Link to="/login">Login</Link></li>
+        {!loggedIn && <li><Link to="/login">Login</Link></li>}
+        {loggedIn && (
+          <li className="profile-container">
+            <button className="profile-button" onClick={() => setOpen(!open)}>
+              <span role="img" aria-label="profile">👦</span>
+            </button>
+            {open && (
+              <ul className="profile-dropdown">
+                <li><Link to="/profile" onClick={() => setOpen(false)}>Profile</Link></li>
+                <li><button onClick={handleLogout}>Log out</button></li>
+              </ul>
+            )}
+          </li>
+        )}
       </ul>
     </nav>
   );

--- a/codespace/frontend/src/pages/ProfilePage.js
+++ b/codespace/frontend/src/pages/ProfilePage.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import NavBar from '../components/NavBar';
+
+function ProfilePage() {
+  return (
+    <div>
+      <NavBar />
+      <h1>Profile Page</h1>
+    </div>
+  );
+}
+
+export default ProfilePage;

--- a/codespace/frontend/src/styles/NavBar.css
+++ b/codespace/frontend/src/styles/NavBar.css
@@ -42,3 +42,46 @@
 .navbar-links a:hover {
   color: #1976d2;
 }
+
+.profile-container {
+  position: relative;
+}
+
+.profile-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.5rem;
+}
+
+.profile-dropdown {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  background: #fff;
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem 0;
+  border: 1px solid #ccc;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.profile-dropdown li {
+  padding: 0.5rem 1rem;
+}
+
+.profile-dropdown li:hover {
+  background: #f0f0f0;
+}
+
+.profile-dropdown li a,
+.profile-dropdown li button {
+  background: none;
+  border: none;
+  text-decoration: none;
+  color: #333;
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+}


### PR DESCRIPTION
## Summary
- Hide login link when authenticated and display a profile dropdown with access to profile and logout.
- Style navigation bar to support profile dropdown interactions.
- Add basic profile page and routing.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e0252065c8328bfba6aab2faf43a0