### PR TITLE
Add backend URL config fallback for frontend

### DIFF
--- a/codespace/frontend/src/components/CreateNewRoom.js
+++ b/codespace/frontend/src/components/CreateNewRoom.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { v4 } from 'uuid';
 import { useNavigate } from 'react-router-dom';
+import BACKEND_URL from '../config';
 
 export default function CreateNewRoom({ onBack }) {
   const navigate = useNavigate();
@@ -9,7 +10,6 @@ export default function CreateNewRoom({ onBack }) {
   const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState('');
   const [roomId, setRoomId] = useState(v4());
-  const API_BASE_URL = process.env.REACT_APP_BACKEND_URL;
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -18,7 +18,7 @@ export default function CreateNewRoom({ onBack }) {
       return;
     }
     try {
-      const res = await fetch(`${API_BASE_URL}/api/rooms/create`, {
+      const res = await fetch(`${BACKEND_URL}/api/rooms/create`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ roomid: roomId, isPrivate, password: isPrivate ? password : undefined }),

--- a/codespace/frontend/src/components/JoinRoom.js
+++ b/codespace/frontend/src/components/JoinRoom.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import BACKEND_URL from '../config';
 
 export default function JoinRoom({ onCreateClick }) {
   const navigate = useNavigate();
@@ -7,14 +8,13 @@ export default function JoinRoom({ onCreateClick }) {
   const [password, setPassword] = useState('');
   const [needsPassword, setNeedsPassword] = useState(false);
   const [error, setError] = useState('');
-  const API_BASE_URL = process.env.REACT_APP_BACKEND_URL;
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     const body = { roomid };
     if (needsPassword) body.password = password;
     try {
-      const res = await fetch(`${API_BASE_URL}/api/rooms/join`, {
+      const res = await fetch(`${BACKEND_URL}/api/rooms/join`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),

--- a/codespace/frontend/src/components/LHS/CFparser.js
+++ b/codespace/frontend/src/components/LHS/CFparser.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import axios from 'axios';
+import BACKEND_URL from '../../config';
 
 const CFparser = ({setStatement,setProblemName,setSampleInput,setSampleOutput,setInput}) => {
   const [param, setparam] = useState('');
@@ -85,7 +86,7 @@ const CFparser = ({setStatement,setProblemName,setSampleInput,setSampleOutput,se
       setError(null);
       try {
         const encodedURL = encodeURIComponent(param);
-        const response = await axios.get(`${process.env.REACT_APP_BACKEND_URL}/api/parse_problem/${encodedURL}`);
+        const response = await axios.get(`${BACKEND_URL}/api/parse_problem/${encodedURL}`);
         go(response.data);
       } catch (err) {   
         setError(err.message);

--- a/codespace/frontend/src/components/LHS/MainLHS.js
+++ b/codespace/frontend/src/components/LHS/MainLHS.js
@@ -4,8 +4,9 @@ import 'katex/dist/katex.min.css';
 import NestedModal from './NestedModal';
 import axios from 'axios';
 import Samples from './Samples';
+import BACKEND_URL from '../../config';
 
-const api = `${process.env.REACT_APP_BACKEND_URL}/api/problem-list`;
+const api = `${BACKEND_URL}/api/problem-list`;
 
 export default function MainLHS({socketRef,currentProbId,setCurrentProb}) {
   // when we change the problem, just broadcast the problem id, and everything will change

--- a/codespace/frontend/src/components/LHS/NestedModal.js
+++ b/codespace/frontend/src/components/LHS/NestedModal.js
@@ -7,6 +7,7 @@ import axios from 'axios';
 import {v4 as uuidv4} from 'uuid';
 import ProblemList from './ProblemList';
 import CFparser from './CFparser';
+import BACKEND_URL from '../../config';
 
 const style = {
   position: 'absolute',
@@ -23,7 +24,7 @@ const style = {
   overflow: 'auto',
 };
 
-const api = `${process.env.REACT_APP_BACKEND_URL}/api/new`
+const api = `${BACKEND_URL}/api/new`
 
 function ChildModal({socketRef, text,setText,input,setInput}) {
   const [open, setOpen] = React.useState(false);

--- a/codespace/frontend/src/components/LHS/ProblemList.js
+++ b/codespace/frontend/src/components/LHS/ProblemList.js
@@ -1,7 +1,8 @@
 import axios from 'axios';
 import React, { useEffect, useState } from 'react'
+import BACKEND_URL from '../../config';
 
-const api = `${process.env.REACT_APP_BACKEND_URL}/api/problem-list`;
+const api = `${BACKEND_URL}/api/problem-list`;
 
 function ProblemList({socketRef , setCurrentProb , setProblemName, setSampleInput, setSampleOutput, setInput}) {
     const [data, setData] = useState([]);

--- a/codespace/frontend/src/components/Room.js
+++ b/codespace/frontend/src/components/Room.js
@@ -6,8 +6,9 @@ import { useState , useRef } from 'react';
 import MiniDrawer from './SideDrawer';
 import Split from 'react-split';
 import MainLHS from './LHS/MainLHS';
-import io from 'socket.io-client';  
+import io from 'socket.io-client';
 import SimplePeer from 'simple-peer';
+import BACKEND_URL from '../config';
 
 import styled from "styled-components";
 
@@ -84,7 +85,7 @@ export default function Room() {
     }
             }
           // socketRef.current.emit('join room',{roomid: roomid , userid: userid});
-          socketRef.current = io(process.env.REACT_APP_BACKEND_URL, { transports: ['websocket'] });
+          socketRef.current = io(BACKEND_URL, { transports: ['websocket'] });
       socketRef.current.emit('join room',{roomid: roomid , userid: userid});
           socketRef.current.on('receive message',(payload) => {
             console.log(`I am ${userid}`);

--- a/codespace/frontend/src/components/TextBox.js
+++ b/codespace/frontend/src/components/TextBox.js
@@ -3,10 +3,11 @@ import axios from 'axios';
 import '../styles/App.css';
 import CodeMirror from '@uiw/react-codemirror';
 import { cpp } from '@codemirror/lang-cpp';
+import BACKEND_URL from '../config';
 
 // Replace with the URL you want to send the request to
-const apiUrl = `${process.env.REACT_APP_BACKEND_URL}/test`; // cpp compilation docker container 
-const submitUrl = `${process.env.REACT_APP_BACKEND_URL}/submit`; 
+const apiUrl = `${BACKEND_URL}/test`; // cpp compilation docker container
+const submitUrl = `${BACKEND_URL}/submit`;
 const defaultText = "#include <bits/stdc++.h>\nusing namespace std;\n\nint main(){\n int t;\n cin >> t;\n while(t--){\n\n }\n}";
 
 export default function TextBox({socketRef,currentProbId}) {

--- a/codespace/frontend/src/config.js
+++ b/codespace/frontend/src/config.js
@@ -1,0 +1,2 @@
+const BACKEND_URL = process.env.REACT_APP_BACKEND_URL || 'http://localhost:6909';
+export default BACKEND_URL;

--- a/codespace/frontend/src/pages/LoginPage.js
+++ b/codespace/frontend/src/pages/LoginPage.js
@@ -1,19 +1,19 @@
 import React, { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import '../styles/LoginPage.css';
+import BACKEND_URL from '../config';
 
 function LoginPage() {
   const [identifier, setIdentifier] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const navigate = useNavigate();
-  const API_BASE_URL = process.env.REACT_APP_BACKEND_URL;
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError('');
     try {
-      const res = await fetch(`${API_BASE_URL}/api/auth/login`, {
+      const res = await fetch(`${BACKEND_URL}/api/auth/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ identifier, password }),

--- a/codespace/frontend/src/pages/SignupPage.js
+++ b/codespace/frontend/src/pages/SignupPage.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import '../styles/SignupPage.css';
+import BACKEND_URL from '../config';
 
 function SignupPage() {
   const [username, setUsername] = useState('');
@@ -9,7 +10,6 @@ function SignupPage() {
   const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState('');
   const navigate = useNavigate();
-  const API_BASE_URL = process.env.REACT_APP_BACKEND_URL;
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -19,7 +19,7 @@ function SignupPage() {
     }
     setError('');
     try {
-      const res = await fetch(`${API_BASE_URL}/api/auth/register`, {
+      const res = await fetch(`${BACKEND_URL}/api/auth/register`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, email, password }),


### PR DESCRIPTION
## Summary
- Centralize backend URL configuration with fallback to localhost
- Replace environment variable usage with config import and direct use across components and auth pages

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_689e1bfedb888328a1333ebe26cc2436