### PR TITLE
Set default concurrency for BullMQ workers

### DIFF
--- a/codespace/server/jobs/submissionWorker.js
+++ b/codespace/server/jobs/submissionWorker.js
@@ -157,7 +157,8 @@ function waitforJobCompletion(queue,job){
 
 const worker = new Worker('submissionProcess',submissionWorker,{
   connection: connectionOptions,
-  concurrency: parseInt(process.env.CONCURRENT_SUBMISSION_WORKERS)
+  // Default to a single worker if the environment variable is undefined or invalid
+  concurrency: parseInt(process.env.CONCURRENT_SUBMISSION_WORKERS, 10) || 1
 });
 
 module.exports = {submissionQueue, submissionWorker: worker, waitforJobCompletion};

--- a/codespace/server/jobs/webScrapingWorker.js
+++ b/codespace/server/jobs/webScrapingWorker.js
@@ -48,7 +48,8 @@ async function scrapingWorker(job) {
 
 const worker = new Worker('scrapingProcess',scrapingWorker, {
     connection: connectionOptions,
-    concurrency: parseInt(process.env.CONCURRENT_SCRAPING_WORKERS)
+    // Default to a single worker if the environment variable is undefined or invalid
+    concurrency: parseInt(process.env.CONCURRENT_SCRAPING_WORKERS, 10) || 1
 });
     
 


### PR DESCRIPTION
## Summary
- prevent BullMQ worker initialization errors by defaulting to 1 worker when `CONCURRENT_*_WORKERS` env vars are missing

## Testing
- `npm start` *(fails: The `uri` parameter to `openUri()` must be a string, got "undefined". Make sure the first parameter to `mongoose.connect()` or `mongoose.createConnection()` is a string.)*


------
https://chatgpt.com/codex/tasks/task_e_689e2619cd14832894a7d6aebcd4e48c