### PR TITLE
Add default MongoDB URI and improve connection handling

### DIFF
--- a/codespace/server/.env
+++ b/codespace/server/.env
@@ -1,1 +1,2 @@
 BACKEND_URL=http://localhost:6909
+MONGODB_URI=mongodb://localhost:27017/stuff

--- a/codespace/server/routes/api.js
+++ b/codespace/server/routes/api.js
@@ -2,7 +2,8 @@ const express = require('express')
 const mongoose = require('mongoose');
 require('dotenv').config();
 const router = express.Router();
-const url = process.env.MONGODB_URI;
+// Use provided MongoDB connection string or fall back to a local instance
+const url = process.env.MONGODB_URI || 'mongodb://localhost:27017/stuff';
 const {QueueEvents} = require('bullmq');
 const { redisClient } = require('../model/redisModel');
 const {scrapingQueue} = require('../jobs/webScrapingWorker')
@@ -25,7 +26,9 @@ const testsSchema = new mongoose.Schema({
 
 const problem_model = mongoose.model('Problem Packages',ProblemSchema);
 // const tests_model = mongoose.model('Test Packages',testsSchema);
-mongoose.connect(url);
+mongoose.connect(url).catch(err => {
+  console.error('Failed to connect to MongoDB:', err.message);
+});
 
 function newProblem(data){
   const {


### PR DESCRIPTION
## Summary
- Provide a fallback MongoDB URI and add connection error logging to avoid undefined URI issues
- Add default `MONGODB_URI` to server `.env` for local development

## Testing
- `npm test` (fails: Missing script "test")
- `npm start` (fails: Redis connection ECONNREFUSED)

------
https://chatgpt.com/codex/tasks/task_e_689e2fdc93b88328b44aef78112145a0