### PR TITLE
Rebrand site to Code Hub and list public rooms

### DIFF
--- a/codespace/frontend/public/index.html
+++ b/codespace/frontend/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Code Hub</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/codespace/frontend/public/manifest.json
+++ b/codespace/frontend/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Code Hub",
+  "name": "Code Hub",
   "icons": [
     {
       "src": "favicon.ico",

--- a/codespace/frontend/src/assets/images/logo.svg
+++ b/codespace/frontend/src/assets/images/logo.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
   <rect width="64" height="64" rx="8" fill="#1976d2"/>
-  <text x="32" y="42" font-family="'Segoe UI', sans-serif" font-size="32" fill="#fff" text-anchor="middle">UG</text>
+  <text x="32" y="42" font-family="'Segoe UI', sans-serif" font-size="32" fill="#fff" text-anchor="middle">CH</text>
 </svg>

--- a/codespace/frontend/src/components/NavBar.js
+++ b/codespace/frontend/src/components/NavBar.js
@@ -25,8 +25,8 @@ function NavBar() {
     <nav className="navbar">
       <div className="navbar-brand">
         <Link to="/" className="brand-link">
-          <img src={logo} alt="USACO Guide logo" className="brand-logo" />
-          <span className="brand-name">USACO Guide</span>
+          <img src={logo} alt="Code Hub logo" className="brand-logo" />
+          <span className="brand-name">Code Hub</span>
         </Link>
       </div>
       <ul className="navbar-links">

--- a/codespace/frontend/src/components/PublicRoomsList.js
+++ b/codespace/frontend/src/components/PublicRoomsList.js
@@ -1,0 +1,68 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import BACKEND_URL from '../config';
+
+export default function PublicRoomsList() {
+  const [rooms, setRooms] = useState([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    async function fetchRooms() {
+      try {
+        const res = await fetch(`${BACKEND_URL}/api/rooms/public`);
+        if (res.ok) {
+          const data = await res.json();
+          setRooms(data);
+        }
+      } catch (err) {
+        console.error('Failed to fetch rooms');
+      }
+    }
+    fetchRooms();
+  }, []);
+
+  const joinRoom = async (roomid) => {
+    try {
+      const res = await fetch(`${BACKEND_URL}/api/rooms/join`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ roomid }),
+      });
+      if (res.ok) {
+        localStorage.setItem('roomid', roomid);
+        navigate('/room');
+      } else {
+        const data = await res.json();
+        alert(data.message || 'Error joining room');
+      }
+    } catch (err) {
+      alert('Server error');
+    }
+  };
+
+  const handleJoin = (roomid) => {
+    if (window.confirm(`Join room ${roomid}?`)) {
+      joinRoom(roomid);
+    }
+  };
+
+  const copyId = (e, roomid) => {
+    e.stopPropagation();
+    navigator.clipboard.writeText(roomid);
+  };
+
+  return (
+    <div className="public-rooms-list">
+      {rooms.map((room) => (
+        <div
+          key={room.roomid}
+          className="public-room-item"
+          onClick={() => handleJoin(room.roomid)}
+        >
+          <span>Room {room.roomid}</span>
+          <button onClick={(e) => copyId(e, room.roomid)}>{room.roomid}</button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/codespace/frontend/src/pages/HomePage.js
+++ b/codespace/frontend/src/pages/HomePage.js
@@ -7,7 +7,7 @@ function HomePage() {
     <div className="home-container">
       <NavBar />
       <main className="home-hero">
-        <h1 className="home-title">USACO Guide</h1>
+        <h1 className="home-title">Code Hub</h1>
         <p className="home-tagline">A free collection of curated, high-quality resources</p>
         <p className="home-tagline">to take you from Bronze to Platinum and beyond.</p>
       </main>

--- a/codespace/frontend/src/pages/RoomsPage.js
+++ b/codespace/frontend/src/pages/RoomsPage.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import NavBar from '../components/NavBar';
 import JoinRoom from '../components/JoinRoom';
 import CreateNewRoom from '../components/CreateNewRoom';
+import PublicRoomsList from '../components/PublicRoomsList';
 import '../styles/RoomsPage.css';
 
 function RoomsPage() {
@@ -13,7 +14,10 @@ function RoomsPage() {
         {creating ? (
           <CreateNewRoom onBack={() => setCreating(false)} />
         ) : (
-          <JoinRoom onCreateClick={() => setCreating(true)} />
+          <>
+            <PublicRoomsList />
+            <JoinRoom onCreateClick={() => setCreating(true)} />
+          </>
         )}
       </div>
     </div>

--- a/codespace/frontend/src/styles/RoomsPage.css
+++ b/codespace/frontend/src/styles/RoomsPage.css
@@ -9,10 +9,44 @@
 .rooms-content {
   flex: 1;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  justify-content: flex-start;
   align-items: center;
   background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
   padding: 2rem;
+}
+
+.public-rooms-list {
+  width: 100%;
+  max-width: 400px;
+  max-height: 200px;
+  overflow-y: auto;
+  margin-bottom: 2rem;
+}
+
+.public-room-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background: #fff;
+  margin-bottom: 0.5rem;
+  cursor: pointer;
+}
+
+.public-room-item button {
+  padding: 0.25rem 0.5rem;
+  background-color: #1976d2;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.public-room-item button:hover {
+  background-color: #115293;
 }
 
 .auth-card form div {

--- a/codespace/server/routes/rooms.js
+++ b/codespace/server/routes/rooms.js
@@ -46,4 +46,13 @@ router.post('/join', async (req, res) => {
   }
 });
 
+router.get('/public', async (req, res) => {
+  try {
+    const rooms = await Room.find({ isPrivate: false }).select('roomid -_id');
+    res.json(rooms);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- Rebrand UI to "Code Hub" with updated logo and titles
- Add scrollable public rooms list with copy-to-clipboard IDs and join confirmation
- Provide backend endpoint to fetch public rooms

## Testing
- `npm test -- --watchAll=false` (frontend) *(fails: No tests found)*
- `npm test` (server) *(fails: Missing script "test" )*

------
https://chatgpt.com/codex/tasks/task_e_689f2f5474ec8328b470afa04a2739dd