### PR TITLE
Show usernames in room and polish room UI

### DIFF
--- a/codespace/frontend/src/components/Room.js
+++ b/codespace/frontend/src/components/Room.js
@@ -46,12 +46,13 @@ const Video = (props) => {
 export default function Room() {
     const roomid = localStorage.getItem('roomid');
     const userid = localStorage.getItem('userid');
+    const username = localStorage.getItem('username');
     console.log(`roomid is: ${roomid}`);
     console.log(`userid is: ${userid}`);
     const [peers,setPeers] = useState([]);
     const [isMicOn] = useState(true);
     const [currentProbId,setCurrentProb] = useState(null);
-    const [members_in_room,setMembersInRoom] = useState([userid]);
+    const [members_in_room,setMembersInRoom] = useState([username]);
     const userVideo = useRef();
     const socketRef = useRef();
     const peersRef = useRef([]);
@@ -85,9 +86,8 @@ export default function Room() {
       console.log('breaks applied');
     }
             }
-          // socketRef.current.emit('join room',{roomid: roomid , userid: userid});
           socketRef.current = io(BACKEND_URL, { transports: ['websocket'] });
-      socketRef.current.emit('join room',{roomid: roomid , userid: userid});
+      socketRef.current.emit('join room',{roomid: roomid , userid: userid, username: username});
           socketRef.current.on('receive message',(payload) => {
             console.log(`I am ${userid}`);
             console.log(payload.msg);

--- a/codespace/frontend/src/styles/RoomPage.css
+++ b/codespace/frontend/src/styles/RoomPage.css
@@ -8,3 +8,33 @@
 .editor-background .main {
   flex: 1;
 }
+
+.split {
+  height: 100%;
+}
+
+.LHS-container,
+.RHS-container {
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+}
+
+.member-card {
+  display: flex;
+  align-items: center;
+  padding: 0.25rem 0.5rem;
+  margin-bottom: 0.25rem;
+  border-radius: 8px;
+  background: #f5f5f5;
+}
+
+.member-card .emoji {
+  margin-right: 0.5rem;
+}
+
+.member-card .id {
+  font-size: 0.9rem;
+  font-weight: 500;
+}

--- a/codespace/frontend/src/styles/RoomsPage.css
+++ b/codespace/frontend/src/styles/RoomsPage.css
@@ -13,10 +13,10 @@
 }
 
 .rooms-sidebar {
-  width: 250px;
-  background: #ffffff;
-  border-right: 1px solid #ddd;
-  padding: 1rem;
+  width: 260px;
+  background: #fdfdfd;
+  border-right: 1px solid #e0e0e0;
+  padding: 1.5rem;
   overflow-y: auto;
 }
 
@@ -27,22 +27,25 @@
 }
 
 .room-block {
-  padding: 0.5rem 0.75rem;
-  border: 1px solid #e0e0e0;
+  padding: 0.75rem 1rem;
+  border: 1px solid #d0d7de;
   border-radius: 8px;
   margin-bottom: 0.75rem;
-  background: #f9f9f9;
+  background: #ffffff;
   cursor: pointer;
-  transition: background 0.2s ease;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
 }
 
 .room-block:hover {
-  background: #e6f0ff;
+  background: #eef5ff;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
 }
 
 .room-title {
   font-weight: 600;
   margin-bottom: 0.5rem;
+  color: #333;
 }
 
 .user-list {
@@ -53,7 +56,7 @@
 
 .user-list li {
   font-size: 0.9rem;
-  color: #555;
+  color: #333;
   margin-bottom: 0.25rem;
 }
 

--- a/codespace/server/app.js
+++ b/codespace/server/app.js
@@ -66,15 +66,15 @@ io.on('connection', (socket) => {
     socket.on('join room',(payload) => {
         socket.roomid = payload.roomid;
         socket.userid = payload.userid;
-        
+        socket.username = payload.username;
+
         socket.join(payload.roomid);
         username_to_socket[payload.userid] = socket;
 
-        addUserToRoom(payload.roomid, payload.userid);
-      
+        addUserToRoom(payload.roomid, payload.userid, payload.username);
+
         console.log(`${payload.userid} joined ${payload.roomid}`)
-        // console.log(`the user socket id is: ${socket.id}`);
-        const usersInRoom = getUsersInRoom(payload.roomid);
+        const usersInRoom = getUsersInRoom(payload.roomid).map(u => u.userid);
         io.to(socket.roomid).emit('all users',{users: usersInRoom});
     })
     
@@ -127,7 +127,7 @@ io.on('connection', (socket) => {
     })
 
     socket.on('get-users-in-room', (payload) => {
-        const usersInRoom = getUsersInRoom(socket.roomid);
+        const usersInRoom = getUsersInRoom(socket.roomid).map(u => u.username);
         console.log('someone is asking around');
         socket.emit('users-in-room', { users: usersInRoom });
     });
@@ -137,7 +137,7 @@ io.on('connection', (socket) => {
         // this is trash bruh
         if (socket.roomid) {
           removeUserFromRoom(socket.roomid, socket.userid);
-          const usersInRoom = getUsersInRoom(socket.roomid);
+          const usersInRoom = getUsersInRoom(socket.roomid).map(u => u.username);
           io.to(socket.roomid).emit('users-in-room', { users: usersInRoom });
 
           console.log('users currently in room are: ' + usersInRoom);

--- a/codespace/server/routes/rooms.js
+++ b/codespace/server/routes/rooms.js
@@ -52,7 +52,7 @@ router.get('/public', async (req, res) => {
     const rooms = await Room.find({ isPrivate: false }).select('roomid -_id');
     const roomsWithUsers = rooms.map((r) => ({
       roomid: r.roomid,
-      users: getUsersInRoom(r.roomid),
+      users: getUsersInRoom(r.roomid).map(u => u.username),
     }));
     res.json(roomsWithUsers);
   } catch (err) {

--- a/codespace/server/utils/roomStore.js
+++ b/codespace/server/utils/roomStore.js
@@ -1,15 +1,15 @@
 const rooms = {};
 
-function addUserToRoom(roomid, userid) {
+function addUserToRoom(roomid, userid, username) {
   if (!rooms[roomid]) {
     rooms[roomid] = [];
   }
-  rooms[roomid].push(userid);
+  rooms[roomid].push({ userid, username });
 }
 
 function removeUserFromRoom(roomid, userid) {
   if (!rooms[roomid]) return;
-  rooms[roomid] = rooms[roomid].filter((u) => u !== userid);
+  rooms[roomid] = rooms[roomid].filter((u) => u.userid !== userid);
   if (rooms[roomid].length === 0) {
     delete rooms[roomid];
   }


### PR DESCRIPTION
## Summary
- Track usernames on the server and emit them to clients
- Display usernames in room member list and send username on join
- Improve styling of room view and room listings

## Testing
- `npm test` (server) *(fails: Missing script: "test")*
- `npm test -- --watchAll=false` (frontend) *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689f409851308328b1ea66340f413f53