### PR TITLE
Align room join/create UI and contain room scrolling

### DIFF
--- a/codespace/frontend/src/components/CreateNewRoom.js
+++ b/codespace/frontend/src/components/CreateNewRoom.js
@@ -75,9 +75,9 @@ export default function CreateNewRoom({ onBack }) {
         {error && <p>{error}</p>}
         <button type="submit">Create</button>
       </form>
-      <p>
-        <button type="button" onClick={onBack}>Back to join</button>
-      </p>
-    </div>
-  );
-}
+        <p className="switch-link">
+          <button type="button" onClick={onBack}>Back to join</button>
+        </p>
+      </div>
+    );
+  }

--- a/codespace/frontend/src/components/JoinRoom.js
+++ b/codespace/frontend/src/components/JoinRoom.js
@@ -64,10 +64,10 @@ export default function JoinRoom({ onCreateClick }) {
         <br />
         <button type="submit">Join</button>
       </form>
-      <p>
-        Don't want to join?{' '}
-        <button type="button" onClick={onCreateClick}>Create a room</button>
-      </p>
-    </div>
-  );
-}
+        <p className="switch-link">
+          Don't want to join?{' '}
+          <button type="button" onClick={onCreateClick}>Create a room</button>
+        </p>
+      </div>
+    );
+  }

--- a/codespace/frontend/src/components/Room.js
+++ b/codespace/frontend/src/components/Room.js
@@ -17,10 +17,11 @@ import styled from "styled-components";
 const Container = styled.div`
     padding: 20px;
     display: flex;
-    height: 100vh;
     width: 90%;
     margin: auto;
     flex-wrap: wrap;
+    max-height: 40vh;
+    overflow-y: auto;
 `;
 
 const StyledVideo = styled.video`

--- a/codespace/frontend/src/components/SideDrawer.js
+++ b/codespace/frontend/src/components/SideDrawer.js
@@ -6,8 +6,8 @@ import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import HeadsetMicIcon from '@mui/icons-material/HeadsetMic';
 
-const drawerWidth = 180 ;
-const closedWidth = 23;
+const drawerWidth = 240;
+const closedWidth = 30;
 
 const openedMixin = (theme) => ({
   width: drawerWidth,
@@ -53,6 +53,13 @@ const ContentContainer = styled('div')(({ open, theme }) => ({
   flexGrow: 1,
   padding: theme.spacing(10),
 }));
+
+const MembersContainer = styled('div')({
+  overflowY: 'auto',
+  maxHeight: 'calc(100vh - 120px)',
+  width: '100%',
+  paddingRight: '8px',
+});
 
 const emojis = ['🧑', '👨', '🧔', '', '', '', '', '']; // Fill in with your desired emojis
 
@@ -101,12 +108,11 @@ export default function MiniDrawer({toggleMic,members_in_room}) {
 
         <div>
           {open ? <p>Members in room</p> : <p></p>}
-          {/* <p>Members in room</p> */}
-          <div>
+          <MembersContainer>
             {members_in_room.map((member, index) => (
-          <MemberCard key={index} id={index} member={member} />
-        ))}
-          </div>
+              <MemberCard key={index} id={index} member={member} />
+            ))}
+          </MembersContainer>
         </div>
         {/* Your drawer content goes here */}
       </Drawer>

--- a/codespace/frontend/src/styles/AuthPage.css
+++ b/codespace/frontend/src/styles/AuthPage.css
@@ -35,17 +35,20 @@
 
 .auth-card button {
   margin-top: 0.5rem;
-  padding: 0.75rem;
+  padding: 0.75rem 1.5rem;
   background-color: #1976d2;
   color: #fff;
   border: none;
   border-radius: 8px;
   cursor: pointer;
   font-size: 1rem;
+  align-self: center;
+  transition: background-color 0.3s ease, transform 0.2s ease;
 }
 
 .auth-card button:hover {
   background-color: #115293;
+  transform: scale(1.02);
 }
 
 .error {
@@ -57,4 +60,17 @@
 .switch-link {
   text-align: center;
   margin-top: 1rem;
+}
+
+.switch-link button {
+  background: none;
+  border: none;
+  color: #1976d2;
+  cursor: pointer;
+  padding: 0;
+  font-size: 1rem;
+}
+
+.switch-link button:hover {
+  text-decoration: underline;
 }

--- a/codespace/frontend/src/styles/RoomPage.css
+++ b/codespace/frontend/src/styles/RoomPage.css
@@ -1,12 +1,15 @@
 .editor-background {
   min-height: 100vh;
+  height: 100vh;
   background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 .editor-background .main {
   flex: 1;
+  overflow: hidden;
 }
 
 .split {
@@ -37,4 +40,5 @@
 .member-card .id {
   font-size: 0.9rem;
   font-weight: 500;
+  overflow-wrap: anywhere;
 }

--- a/codespace/frontend/src/styles/RoomsPage.css
+++ b/codespace/frontend/src/styles/RoomsPage.css
@@ -64,7 +64,7 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  justify-content: flex-start;
+  justify-content: center;
   align-items: center;
   background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
   padding: 2rem;


### PR DESCRIPTION
## Summary
- Center and smooth room join/create buttons
- Make create-room page use small switch links like auth forms
- Widen room members sidebar and confine page scrolling to drawer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f45714af88328a452f57b7ba3f1a4