### PR TITLE
Enhance room sidebar with copy button and member sync

### DIFF
--- a/codespace/frontend/src/components/Room.js
+++ b/codespace/frontend/src/components/Room.js
@@ -60,11 +60,6 @@ export default function Room() {
     // TODO: get the username
     // TODO: we join room here
 
-    const handleCopyRoomId = () => {
-      navigator.clipboard.writeText(roomid);
-      alert('Room ID copied to clipboard');
-    };
-    
     const toggleMic = () => {
       console.log("hey man!");
       turnonmic();
@@ -184,12 +179,8 @@ export default function Room() {
       return (
         <div className="editor-background">
         <div className='main'>
-            <div className="roomid-copy">
-              <span>Room ID: {roomid}</span>
-              <button onClick={handleCopyRoomId}>Copy</button>
-            </div>
-            <Split
-                sizes={[20, 80]}
+              <Split
+                  sizes={[20, 80]}
                 minSize={200}
                 maxSize={1000}
                 direction="horizontal"
@@ -209,7 +200,7 @@ export default function Room() {
                     <TextBox socketRef={socketRef} currentProbId={currentProbId} />
                 </div>
             </Split>
-            <MiniDrawer toggleMic={toggleMic} members_in_room={members_in_room} />
+              <MiniDrawer toggleMic={toggleMic} members_in_room={members_in_room} roomid={roomid} />
             {/* <AudioRecorder socket={socket} username={username} roomid={roomid}/> */}
             <Container>
                 <StyledVideo muted ref={userVideo} autoPlay playsInline />

--- a/codespace/frontend/src/components/SideDrawer.js
+++ b/codespace/frontend/src/components/SideDrawer.js
@@ -5,8 +5,10 @@ import IconButton from '@mui/material/IconButton';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import HeadsetMicIcon from '@mui/icons-material/HeadsetMic';
+import Button from '@mui/material/Button';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 
-const drawerWidth = 240;
+const drawerWidth = '20%';
 const closedWidth = 30;
 
 const openedMixin = (theme) => ({
@@ -75,50 +77,67 @@ const MemberCard = ({ id , member}) => {
   );
 };
 
-export default function MiniDrawer({toggleMic,members_in_room}) {
-  const theme = useTheme();
-  const [open, setOpen] = React.useState(false);
+export default function MiniDrawer({toggleMic,members_in_room, roomid}) {
+    const theme = useTheme();
+    const [open, setOpen] = React.useState(false);
+    const [copied, setCopied] = React.useState(false);
 
-  console.log(members_in_room);
+    console.log(members_in_room);
 
-  const handleDrawerOpen = () => {
-    setOpen(true);
-  };
+    const handleDrawerOpen = () => {
+      setOpen(true);
+    };
 
-  const handleDrawerClose = () => {
-    setOpen(false);
-  };
+    const handleDrawerClose = () => {
+      setOpen(false);
+    };
 
-  return (
-    <div>
-      <Drawer variant="permanent" open={open}>
-        <IconButton
-          // color="inherit"
-          aria-label="open drawer"
-          onClick={open ? handleDrawerClose : handleDrawerOpen}
-          edge="start"
-        >
-          {open ? <ChevronLeftIcon /> : <ChevronRightIcon />}
-        </IconButton>
+    const handleCopyRoomId = () => {
+      navigator.clipboard.writeText(roomid);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    };
 
-        <IconButton variant="contained" color="primary" onClick={toggleMic}>
-          <HeadsetMicIcon />
-        </IconButton>
-        
+    return (
+      <div>
+        <Drawer variant="permanent" open={open}>
+          <div style={{display:'flex', flexDirection:'column', height:'100%'}}>
+            <IconButton
+              aria-label="open drawer"
+              onClick={open ? handleDrawerClose : handleDrawerOpen}
+              edge="start"
+            >
+              {open ? <ChevronLeftIcon /> : <ChevronRightIcon />}
+            </IconButton>
 
-        <div>
-          {open ? <p>Members in room</p> : <p></p>}
-          <MembersContainer>
-            {members_in_room.map((member, index) => (
-              <MemberCard key={index} id={index} member={member} />
-            ))}
-          </MembersContainer>
-        </div>
-        {/* Your drawer content goes here */}
-      </Drawer>
-      <ContentContainer open={open} theme={theme}>
-        {/* Your main content goes here */}
-      </ContentContainer>
-    </div>
-  );
-}
+            <IconButton variant="contained" color="primary" onClick={toggleMic}>
+              <HeadsetMicIcon />
+            </IconButton>
+
+            <div style={{flexGrow: 1}}>
+              {open ? <p>Members in room</p> : <p></p>}
+              <MembersContainer>
+                {members_in_room.map((member, index) => (
+                  <MemberCard key={index} id={index} member={member} />
+                ))}
+              </MembersContainer>
+            </div>
+
+            {open && (
+              <Button
+                variant="outlined"
+                startIcon={<ContentCopyIcon />}
+                onClick={handleCopyRoomId}
+                sx={{mt: 'auto', mb: 1, mx: 1}}
+              >
+                {copied ? 'Copied!' : 'Copy Room ID'}
+              </Button>
+            )}
+          </div>
+        </Drawer>
+        <ContentContainer open={open} theme={theme}>
+          {/* Your main content goes here */}
+        </ContentContainer>
+      </div>
+    );
+  }

--- a/codespace/frontend/src/styles/RoomPage.css
+++ b/codespace/frontend/src/styles/RoomPage.css
@@ -43,16 +43,3 @@
   overflow-wrap: anywhere;
 }
 
-.roomid-copy {
-  margin: 0.5rem;
-  display: inline-flex;
-  align-items: center;
-  background: #ffffff;
-  padding: 0.25rem 0.5rem;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
-.roomid-copy button {
-  margin-left: 0.5rem;
-}

--- a/codespace/server/app.js
+++ b/codespace/server/app.js
@@ -74,8 +74,9 @@ io.on('connection', (socket) => {
         addUserToRoom(payload.roomid, payload.userid, payload.username);
 
         console.log(`${payload.userid} joined ${payload.roomid}`)
-        const usersInRoom = getUsersInRoom(payload.roomid).map(u => u.userid);
-        io.to(socket.roomid).emit('all users',{users: usersInRoom});
+        const usersInRoom = getUsersInRoom(payload.roomid);
+        io.to(socket.roomid).emit('all users',{users: usersInRoom.map(u => u.userid)});
+        io.to(socket.roomid).emit('users-in-room', { users: usersInRoom.map(u => u.username) });
     })
     
     socket.on('update-code', (payload) => {


### PR DESCRIPTION
## Summary
- Add room member broadcasts on join for real-time updates
- Move room ID copy button to sidebar with 20% width and visual feedback
- Clean up old copy button styles

## Testing
- `npm test` (server) *(fails: Missing script)*
- `CI=true npm test` (frontend) *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689f8e4f2a288328a71643265d123118