### PR TITLE
Improve room sidebar design and live member updates

### DIFF
--- a/codespace/frontend/src/components/Room.js
+++ b/codespace/frontend/src/components/Room.js
@@ -53,7 +53,6 @@ export default function Room() {
     const [peers,setPeers] = useState([]);
     const [isMicOn] = useState(true);
     const [currentProbId,setCurrentProb] = useState(null);
-    const [members_in_room,setMembersInRoom] = useState([username]);
     const userVideo = useRef();
     const socketRef = useRef();
     const peersRef = useRef([]);
@@ -109,7 +108,6 @@ export default function Room() {
               }
             })
             setPeers(peers);
-            socketRef.current.emit('get-users-in-room');
           })
     
           socketRef.current.on('offer received', (payload) => {
@@ -136,11 +134,6 @@ export default function Room() {
             item.peer.signal(payload.signal);
           })
 
-          socketRef.current.on('users-in-room',(payload) => {
-            console.log('users in room are ' + payload.users);
-            setMembersInRoom(payload.users);
-          })
-    
         })
       }
 
@@ -200,7 +193,7 @@ export default function Room() {
                     <TextBox socketRef={socketRef} currentProbId={currentProbId} />
                 </div>
             </Split>
-              <MiniDrawer toggleMic={toggleMic} members_in_room={members_in_room} roomid={roomid} />
+              <MiniDrawer toggleMic={toggleMic} socketRef={socketRef} roomid={roomid} />
             {/* <AudioRecorder socket={socket} username={username} roomid={roomid}/> */}
             <Container>
                 <StyledVideo muted ref={userVideo} autoPlay playsInline />

--- a/codespace/server/utils/roomStore.js
+++ b/codespace/server/utils/roomStore.js
@@ -4,7 +4,9 @@ function addUserToRoom(roomid, userid, username) {
   if (!rooms[roomid]) {
     rooms[roomid] = [];
   }
-  rooms[roomid].push({ userid, username });
+  if (!rooms[roomid].some((u) => u.userid === userid)) {
+    rooms[roomid].push({ userid, username });
+  }
 }
 
 function removeUserFromRoom(roomid, userid) {


### PR DESCRIPTION
## Summary
- Restyle room sidebar and copy ID button, shrink drawer to 15%
- Load room member list via socket in sidebar to update without page re-render
- Ensure server-side room member store keeps unique users in memory

## Testing
- `npm test` *(server: Missing script "test")*
- `npm test -- --watchAll=false` *(frontend: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_689f94b2e2a08328ba4000d97b8e915b