### PR TITLE
feat: add docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,20 @@ npm start
 ```
 
 Then open [http://localhost:3000/](http://localhost:3000/) in your browser.
+
+## Running with Docker
+
+Use Docker Compose to run the backend, frontend, MongoDB, and Redis without installing dependencies manually.
+
+```bash
+docker-compose up --build
+```
+
+This starts the services on:
+
+- Frontend: http://localhost:3000
+- API server: http://localhost:6909
+- MongoDB: localhost:27017
+- Redis: localhost:6379
+
+The server uses the `.env` values defined in `docker-compose.yml`. Edit the file if you need different settings.

--- a/codespace/frontend/.dockerignore
+++ b/codespace/frontend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+build
+.env

--- a/codespace/frontend/Dockerfile
+++ b/codespace/frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 3000
+CMD ["npm","start"]

--- a/codespace/server/.dockerignore
+++ b/codespace/server/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+.env

--- a/codespace/server/Dockerfile
+++ b/codespace/server/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 6909
+CMD ["npm","start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3.8'
+services:
+  mongo:
+    image: mongo:6
+    restart: unless-stopped
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+  redis:
+    image: redis:7
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+  server:
+    build: ./codespace/server
+    restart: unless-stopped
+    environment:
+      - MONGODB_URI=mongodb://mongo:27017/graduation_project
+      - TEST_DATA_DIR=./test-data
+      - JWT_SECRET=changeme
+      - REDIS_URL=redis://redis:6379
+    ports:
+      - "6909:6909"
+    depends_on:
+      - mongo
+      - redis
+  frontend:
+    build: ./codespace/frontend
+    restart: unless-stopped
+    environment:
+      - CHOKIDAR_USEPOLLING=true
+    ports:
+      - "3000:3000"
+    depends_on:
+      - server
+volumes:
+  mongo-data:


### PR DESCRIPTION
## Summary
- containerize Node.js server and React frontend
- add docker-compose to run server, frontend, MongoDB, and Redis
- document how to run the stack with Docker

## Testing
- `npm test` (server) *(fails: Missing script: "test")*
- `npm test` (frontend)
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689faed464088328a618953da73a7d5d