### PR TITLE
Add problem listing and detail pages with solving editor

### DIFF
--- a/codespace/frontend/src/App.js
+++ b/codespace/frontend/src/App.js
@@ -2,7 +2,7 @@ import './styles/App.css';
 import HomePage from './pages/HomePage';
 import LoginPage from './pages/LoginPage';
 import SignupPage from './pages/SignupPage';
-import { Route, Routes, BrowserRouter } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 import Room from './components/Room';
 import ContestPage from './pages/ContestPage';
 import RoomsPage from './pages/RoomsPage';
@@ -15,7 +15,6 @@ import ProfilePage from './pages/ProfilePage';
 function App(){
   console.log(process.env);
   return (
-    <BrowserRouter>
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/login" element={<LoginPage />} />
@@ -29,7 +28,6 @@ function App(){
         <Route path="/profile" element={<ProfilePage />} />
         <Route path="/room" element={<Room />} />
       </Routes>
-    </BrowserRouter>
   );
 }
 

--- a/codespace/frontend/src/index.js
+++ b/codespace/frontend/src/index.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 // import './styles/index.css';
 import App from './App';
+import ProblemDetailPage from './pages/ProblemDetailPage';
 import process from 'process';
 
 // Polyfill process for browser environment
@@ -11,5 +13,10 @@ if (!window.process) {
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-    <App />
+  <BrowserRouter>
+    <Routes>
+      <Route path="/problems/:id" element={<ProblemDetailPage />} />
+      <Route path="/*" element={<App />} />
+    </Routes>
+  </BrowserRouter>
 );

--- a/codespace/frontend/src/pages/ProblemDetailPage.js
+++ b/codespace/frontend/src/pages/ProblemDetailPage.js
@@ -1,0 +1,55 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import axios from 'axios';
+import NavBar from '../components/NavBar';
+import TextBox from '../components/TextBox';
+import BACKEND_URL from '../config';
+
+function ProblemDetailPage() {
+  const { id } = useParams();
+  const [problem, setProblem] = useState(null);
+  const socketRef = useRef(null);
+
+  useEffect(() => {
+    async function fetchProblem() {
+      try {
+        const res = await axios.get(`${BACKEND_URL}/api/parse_problem/${id}`);
+        setProblem(res.data);
+      } catch (err) {
+        console.error('Error fetching problem:', err);
+      }
+    }
+    fetchProblem();
+  }, [id]);
+
+  return (
+    <div>
+      <NavBar />
+      {problem ? (
+        <div>
+          <h1>{problem.title}</h1>
+          <div dangerouslySetInnerHTML={{ __html: problem.statement }} />
+          <h2>Sample Tests</h2>
+          {problem.sample_input && problem.sample_outputs && (
+            <ul>
+              {problem.sample_input.map((input, idx) => (
+                <li key={idx}>
+                  <p>Input:</p>
+                  <pre>{input}</pre>
+                  <p>Output:</p>
+                  <pre>{problem.sample_outputs[idx]}</pre>
+                </li>
+              ))}
+            </ul>
+          )}
+          <h2>Solve</h2>
+          <TextBox socketRef={socketRef} currentProbId={id} />
+        </div>
+      ) : (
+        <p>Loading...</p>
+      )}
+    </div>
+  );
+}
+
+export default ProblemDetailPage;

--- a/codespace/frontend/src/pages/ProblemsPage.js
+++ b/codespace/frontend/src/pages/ProblemsPage.js
@@ -1,11 +1,42 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import axios from 'axios';
 import NavBar from '../components/NavBar';
+import BACKEND_URL from '../config';
+
+// Custom hook to fetch the list of problems from the backend
+function useProblemList() {
+  const [problems, setProblems] = useState([]);
+
+  useEffect(() => {
+    async function fetchProblems() {
+      try {
+        const res = await axios.get(`${BACKEND_URL}/api/problem-list`);
+        setProblems(res.data);
+      } catch (err) {
+        console.error('Error fetching problems:', err);
+      }
+    }
+    fetchProblems();
+  }, []);
+
+  return problems;
+}
 
 function ProblemsPage() {
+  const problems = useProblemList();
+
   return (
     <div>
       <NavBar />
       <h1>Problems Page</h1>
+      <ul>
+        {problems.map((problem) => (
+          <li key={problem.id}>
+            {problem.problem_name} <Link to={`/problems/${problem.id}`}>View</Link>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Fetch problems from `/api/problem-list` and display with links
- Build problem detail page that loads problem data and sample tests
- Wire up routes for new problem detail page and adjust router structure

## Testing
- `npm test --prefix frontend -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0757dfac0832887def934ab43ef41