### PR TITLE
Protect room routes with JWT auth

### DIFF
--- a/codespace/frontend/src/components/CreateNewRoom.js
+++ b/codespace/frontend/src/components/CreateNewRoom.js
@@ -16,11 +16,19 @@ export default function CreateNewRoom({ onBack }) {
       return;
     }
     try {
+      const token = localStorage.getItem('token');
       const res = await fetch(`${BACKEND_URL}/api/rooms/create`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({ isPrivate, password: isPrivate ? password : undefined }),
       });
+      if (res.status === 401) {
+        navigate('/login');
+        return;
+      }
       if (res.ok) {
         const data = await res.json();
         localStorage.setItem('roomid', data.roomid);

--- a/codespace/frontend/src/components/JoinRoom.js
+++ b/codespace/frontend/src/components/JoinRoom.js
@@ -11,11 +11,20 @@ export default function JoinRoom({ onCreateClick }) {
     e.preventDefault();
     try {
       // First attempt: check if room requires a password
+      const token = localStorage.getItem('token');
+      const headers = {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      };
       let res = await fetch(`${BACKEND_URL}/api/rooms/join`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers,
         body: JSON.stringify({ roomid }),
       });
+      if (res.status === 401) {
+        navigate('/login');
+        return;
+      }
       let data = await res.json();
 
       // If the room is private prompt the user for its password
@@ -26,12 +35,20 @@ export default function JoinRoom({ onCreateClick }) {
         }
         res = await fetch(`${BACKEND_URL}/api/rooms/join`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers,
           body: JSON.stringify({ roomid, password }),
         });
+        if (res.status === 401) {
+          navigate('/login');
+          return;
+        }
         data = await res.json();
       }
 
+      if (res.status === 401) {
+        navigate('/login');
+        return;
+      }
       if (res.ok) {
         localStorage.setItem('roomid', roomid);
         navigate('/room');

--- a/codespace/server/app.js
+++ b/codespace/server/app.js
@@ -9,6 +9,7 @@ const submit = require("./routes/submit")
 const api1 = require("./routes/api")
 const auth = require("./routes/auth")
 const roomsRoute = require("./routes/rooms")
+const authMiddleware = require('./middleware/authMiddleware')
 const rateLimit = require('express-rate-limit');
 
 const app = express();
@@ -34,7 +35,7 @@ app.use(express.json({limit: '50mb' , extended: true}));
 
 app.use('/api/auth',auth)
 app.use('/api',api1)
-app.use('/api/rooms',roomsRoute)
+app.use('/api/rooms', authMiddleware, roomsRoute)
 app.use('/test',test)
 app.use('/submit',submit)
 

--- a/codespace/server/middleware/authMiddleware.js
+++ b/codespace/server/middleware/authMiddleware.js
@@ -1,0 +1,16 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = function (req, res, next) {
+  const authHeader = req.headers['authorization'];
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ message: 'No token provided' });
+  }
+  const token = authHeader.split(' ')[1];
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'changeme');
+    req.user = decoded;
+    next();
+  } catch (err) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+};


### PR DESCRIPTION
## Summary
- enforce JWT auth via new middleware
- secure /api/rooms routes
- attach auth token and handle 401 redirects in room components

## Testing
- `cd codespace/server && npm test` (fails: Missing script "test")
- `cd codespace/frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a075b4e2248328ba77c9c78bc70d85