### PR TITLE
Persist room members and chat messages in MongoDB

### DIFF
--- a/codespace/server/app.js
+++ b/codespace/server/app.js
@@ -42,7 +42,13 @@ app.get('/', (req, res) => {
     res.send('omg hewwo fren!!');
 });
 
-const { addUserToRoom, removeUserFromRoom, getUsersInRoom, updateMicStatus } = require('./utils/roomStore');
+const {
+  addUserToRoom,
+  removeUserFromRoom,
+  getUsersInRoom,
+  updateMicStatus,
+  addMessage,
+} = require('./utils/roomStore');
 const username_to_socket = {};
 const pairSet = new Map();
 
@@ -64,7 +70,7 @@ function removeuserfrompair(){
 
 io.on('connection', (socket) => {
     socket.emit('welcome',{msg: 'welcome to room'});
-    socket.on('join room',(payload) => {
+    socket.on('join room', async (payload) => {
         socket.roomid = payload.roomid;
         socket.userid = payload.userid;
         socket.username = payload.username;
@@ -72,10 +78,10 @@ io.on('connection', (socket) => {
         socket.join(payload.roomid);
         username_to_socket[payload.userid] = socket;
 
-        addUserToRoom(payload.roomid, payload.userid, payload.username);
+        await addUserToRoom(payload.roomid, payload.userid, payload.username);
 
         console.log(`${payload.userid} joined ${payload.roomid}`)
-        const usersInRoom = getUsersInRoom(payload.roomid);
+        const usersInRoom = await getUsersInRoom(payload.roomid);
         io.to(socket.roomid).emit('all users',{users: usersInRoom.map(u => u.userid)});
         io.to(socket.roomid).emit('users-in-room', { users: usersInRoom.map(u => ({ userid: u.userid, username: u.username, micOn: u.micOn })) });
     })
@@ -88,7 +94,8 @@ io.on('connection', (socket) => {
         io.to(socket.roomid).emit('receive-problem-statement',{statement: payload.statement});
     });
 
-    socket.on('send-message', (payload) => {
+    socket.on('send-message', async (payload) => {
+        await addMessage(socket.roomid, socket.userid, socket.username, payload.msg);
         io.to(socket.roomid).emit('receive message',{msg: payload.msg});
     })
 
@@ -128,23 +135,23 @@ io.on('connection', (socket) => {
         }
     })
 
-    socket.on('mic-status', (payload) => {
-        updateMicStatus(socket.roomid, payload.userid, payload.micOn);
+    socket.on('mic-status', async (payload) => {
+        await updateMicStatus(socket.roomid, payload.userid, payload.micOn);
         io.to(socket.roomid).emit('mic-status', payload);
     });
 
-    socket.on('get-users-in-room', (payload) => {
-        const usersInRoom = getUsersInRoom(socket.roomid);
+    socket.on('get-users-in-room', async (payload) => {
+        const usersInRoom = await getUsersInRoom(socket.roomid);
         console.log('someone is asking around');
         socket.emit('users-in-room', { users: usersInRoom.map(u => ({ userid: u.userid, username: u.username, micOn: u.micOn })) });
     });
 
 
-    socket.on('disconnect', () => {
+    socket.on('disconnect', async () => {
         // this is trash bruh
         if (socket.roomid) {
-          removeUserFromRoom(socket.roomid, socket.userid);
-          const usersInRoom = getUsersInRoom(socket.roomid);
+          await removeUserFromRoom(socket.roomid, socket.userid);
+          const usersInRoom = await getUsersInRoom(socket.roomid);
           io.to(socket.roomid).emit('users-in-room', { users: usersInRoom.map(u => ({ userid: u.userid, username: u.username, micOn: u.micOn })) });
 
           console.log('users currently in room are: ' + usersInRoom.map(u => u.username));

--- a/codespace/server/model/messageModel.js
+++ b/codespace/server/model/messageModel.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+
+const messageSchema = new mongoose.Schema(
+  {
+    roomid: { type: String, required: true },
+    userid: { type: String, required: true },
+    username: { type: String, required: true },
+    message: { type: String, required: true },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Message', messageSchema);

--- a/codespace/server/model/roomUserModel.js
+++ b/codespace/server/model/roomUserModel.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const roomUserSchema = new mongoose.Schema({
+  roomid: { type: String, required: true },
+  userid: { type: String, required: true },
+  username: { type: String, required: true },
+  micOn: { type: Boolean, default: false },
+});
+
+roomUserSchema.index({ roomid: 1, userid: 1 }, { unique: true });
+
+module.exports = mongoose.model('RoomUser', roomUserSchema);

--- a/codespace/server/routes/rooms.js
+++ b/codespace/server/routes/rooms.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const mongoose = require('mongoose');
 const Room = require('../model/roomModel');
-const { getUsersInRoom } = require('../utils/roomStore');
+const { getUsersInRoom, getMessages } = require('../utils/roomStore');
 
 const router = express.Router();
 const url = process.env.MONGODB_URI || 'mongodb://localhost:27017/graduation_project';
@@ -46,17 +46,31 @@ router.post('/join', async (req, res) => {
   }
 });
 
-router.get('/public', async (req, res) => {
-  try {
-    const rooms = await Room.find({ isPrivate: false }).select('roomid -_id');
-    const roomsWithUsers = rooms.map((r) => ({
-      roomid: r.roomid,
-      users: getUsersInRoom(r.roomid).map(u => u.username),
-    }));
-    res.json(roomsWithUsers);
-  } catch (err) {
-    res.status(500).json({ message: 'Server error' });
-  }
-});
+  router.get('/public', async (req, res) => {
+    try {
+      const rooms = await Room.find({ isPrivate: false }).select('roomid -_id');
+      const roomsWithUsers = await Promise.all(
+        rooms.map(async (r) => {
+          const users = await getUsersInRoom(r.roomid);
+          return {
+            roomid: r.roomid,
+            users: users.map(u => u.username),
+          };
+        })
+      );
+      res.json(roomsWithUsers);
+    } catch (err) {
+      res.status(500).json({ message: 'Server error' });
+    }
+  });
+
+  router.get('/:id/messages', async (req, res) => {
+    try {
+      const messages = await getMessages(req.params.id);
+      res.json(messages);
+    } catch (err) {
+      res.status(500).json({ message: 'Server error' });
+    }
+  });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- model: add RoomUser and Message schemas for persisting room membership and chat history
- util: replace in-memory room store with MongoDB-backed helpers for members, messages, and mic status
- server: save chat messages to database and expose message history endpoint

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check app.js`
- `node --check routes/rooms.js`
- `node --check utils/roomStore.js`
- `node --check model/roomUserModel.js`
- `node --check model/messageModel.js`


------
https://chatgpt.com/codex/tasks/task_e_68a075cd9e008328b73d9fde43ae324a