### PR TITLE
Add contest management backend and frontend UI

### DIFF
--- a/codespace/frontend/src/pages/ContestPage.js
+++ b/codespace/frontend/src/pages/ContestPage.js
@@ -1,11 +1,58 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import NavBar from '../components/NavBar';
+import BACKEND_URL from '../config';
 
 function ContestPage() {
+  const [contests, setContests] = useState([]);
+
+  useEffect(() => {
+    async function fetchContests() {
+      try {
+        const res = await fetch(`${BACKEND_URL}/api/contests`);
+        if (res.ok) {
+          const data = await res.json();
+          setContests(data);
+        }
+      } catch (err) {
+        console.error('Failed to fetch contests');
+      }
+    }
+    fetchContests();
+  }, []);
+
+  const register = async (id) => {
+    const userId = localStorage.getItem('userid');
+    try {
+      const res = await fetch(`${BACKEND_URL}/api/contests/${id}/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        alert('Registered');
+      } else {
+        alert(data.message || 'Registration failed');
+      }
+    } catch (err) {
+      alert('Server error');
+    }
+  };
+
   return (
     <div>
       <NavBar />
-      <h2 style={{ textAlign: 'center', marginTop: '2rem' }}>Contest Coming Soon</h2>
+      <div style={{ maxWidth: '600px', margin: '2rem auto' }}>
+        <h2>Upcoming Contests</h2>
+        {contests.map((contest) => (
+          <div key={contest._id} style={{ border: '1px solid #ccc', padding: '1rem', marginBottom: '1rem' }}>
+            <h3>{contest.name}</h3>
+            <p>Start: {new Date(contest.startTime).toLocaleString()}</p>
+            <p>Duration: {contest.duration} minutes</p>
+            <button onClick={() => register(contest._id)}>Register</button>
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/codespace/server/app.js
+++ b/codespace/server/app.js
@@ -8,7 +8,8 @@ const test = require("./routes/test")
 const submit = require("./routes/submit")
 const api1 = require("./routes/api")
 const auth = require("./routes/auth")
-const roomsRoute = require("./routes/rooms")
+const roomsRoute = require("./routes/rooms");
+const contestsRoute = require("./routes/contests")
 const rateLimit = require('express-rate-limit');
 
 const app = express();
@@ -35,6 +36,7 @@ app.use(express.json({limit: '50mb' , extended: true}));
 app.use('/api/auth',auth)
 app.use('/api',api1)
 app.use('/api/rooms',roomsRoute)
+app.use('/api/contests',contestsRoute)
 app.use('/test',test)
 app.use('/submit',submit)
 

--- a/codespace/server/model/contestModel.js
+++ b/codespace/server/model/contestModel.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const contestSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  startTime: { type: Date, required: true },
+  duration: { type: Number, required: true },
+  problems: [{ type: String }],
+  participants: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }]
+});
+
+module.exports = mongoose.model('Contest', contestSchema);

--- a/codespace/server/routes/contests.js
+++ b/codespace/server/routes/contests.js
@@ -1,0 +1,52 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const Contest = require('../model/contestModel');
+
+const router = express.Router();
+const url = process.env.MONGODB_URI || 'mongodb://localhost:27017/graduation_project';
+
+mongoose.connect(url);
+
+// Create a new contest (admin only - auth not implemented here)
+router.post('/', async (req, res) => {
+  const { name, startTime, duration, problems } = req.body;
+  try {
+    const contest = new Contest({ name, startTime, duration, problems });
+    await contest.save();
+    res.status(201).json(contest);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+// List upcoming contests
+router.get('/', async (req, res) => {
+  try {
+    const now = new Date();
+    const contests = await Contest.find({ startTime: { $gte: now } }).sort({ startTime: 1 });
+    res.json(contests);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+// Register a user for a contest
+router.post('/:id/register', async (req, res) => {
+  const { userId } = req.body;
+  try {
+    const contest = await Contest.findById(req.params.id);
+    if (!contest) {
+      return res.status(404).json({ message: 'Contest not found' });
+    }
+    if (contest.participants.includes(userId)) {
+      return res.status(400).json({ message: 'Already registered' });
+    }
+    contest.participants.push(userId);
+    await contest.save();
+    res.json({ message: 'Registered' });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add Contest mongoose model
- expose contest creation, listing, and registration routes
- show upcoming contests with register option on frontend

## Testing
- `npm test` (server) *(fails: Missing script "test")*
- `CI=true npm test -- --watchAll=false` (frontend) *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a075f25f3883288d79839dd9bcaf3d