### PR TITLE
Fix unreadable homepage title color

### DIFF
--- a/codespace/frontend/src/styles/HomePage.css
+++ b/codespace/frontend/src/styles/HomePage.css
@@ -22,10 +22,7 @@
 .home-title {
   font-size: 3rem;
   margin-bottom: 1rem;
-  background: linear-gradient(90deg, #ffecd2, #fcb69f);
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
+  color: #1a1a1a;
   animation: fadeIn 2s ease-in-out;
 }
 


### PR DESCRIPTION
## Summary
- make the "Code Hub" heading on the homepage a dark gray for better contrast

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a0d4d48df08328a26ba45c73637871