### PR TITLE
feat: add resources filters layout

### DIFF
--- a/codespace/frontend/src/pages/ResourcesPage.js
+++ b/codespace/frontend/src/pages/ResourcesPage.js
@@ -1,11 +1,81 @@
-import React from 'react';
+import React, { useState } from 'react';
 import NavBar from '../components/NavBar';
+import '../styles/ResourcesPage.css';
+
+const topics = {
+  'Graph Algorithms': ['BFS', 'DFS'],
+  'Dynamic Programming': ['Knapsack', 'LIS'],
+};
+
+const resourcesData = [
+  { id: 1, name: 'BFS Tutorial', link: 'https://example.com/bfs', topic: 'Graph Algorithms', subtopic: 'BFS', status: 'Not Attempted' },
+  { id: 2, name: 'DFS Guide', link: 'https://example.com/dfs', topic: 'Graph Algorithms', subtopic: 'DFS', status: 'Solving' },
+  { id: 3, name: 'Knapsack Article', link: 'https://example.com/knapsack', topic: 'Dynamic Programming', subtopic: 'Knapsack', status: 'Solved' },
+  { id: 4, name: 'LIS Explained', link: 'https://example.com/lis', topic: 'Dynamic Programming', subtopic: 'LIS', status: 'Reviewing' },
+];
 
 function ResourcesPage() {
+  const [search, setSearch] = useState('');
+  const [selectedTopic, setSelectedTopic] = useState('');
+  const [selectedSubtopic, setSelectedSubtopic] = useState('');
+
+  const handleTopicChange = (e) => {
+    setSelectedTopic(e.target.value);
+    setSelectedSubtopic('');
+  };
+
+  const filteredResources = resourcesData.filter((r) => {
+    const matchesTopic = selectedTopic ? r.topic === selectedTopic : true;
+    const matchesSubtopic = selectedSubtopic ? r.subtopic === selectedSubtopic : true;
+    const matchesSearch = r.name.toLowerCase().includes(search.toLowerCase());
+    return matchesTopic && matchesSubtopic && matchesSearch;
+  });
+
   return (
     <div>
       <NavBar />
-      <h1>Resources Page</h1>
+      <div className="resources-page">
+        <div className="search-bar">
+          <input
+            type="text"
+            placeholder="Search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+        <div className="resources-content">
+          <div className="left-menu">
+            <select value={selectedTopic} onChange={handleTopicChange}>
+              <option value="">All Topics</option>
+              {Object.keys(topics).map((topic) => (
+                <option key={topic} value={topic}>{topic}</option>
+              ))}
+            </select>
+            <select
+              value={selectedSubtopic}
+              onChange={(e) => setSelectedSubtopic(e.target.value)}
+              disabled={!selectedTopic}
+            >
+              <option value="">All Subtopics</option>
+              {selectedTopic && topics[selectedTopic].map((sub) => (
+                <option key={sub} value={sub}>{sub}</option>
+              ))}
+            </select>
+          </div>
+          <div className="right-resources">
+            {filteredResources.map((res) => {
+              const statusClass = `status-${res.status.toLowerCase().replace(/ /g, '-')}`;
+              return (
+                <div key={res.id} className="resource-card">
+                  <h3>{res.name}</h3>
+                  <a href={res.link} target="_blank" rel="noopener noreferrer">{res.link}</a>
+                  <div className={`status-circle ${statusClass}`} title={res.status}></div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/codespace/frontend/src/styles/ResourcesPage.css
+++ b/codespace/frontend/src/styles/ResourcesPage.css
@@ -1,0 +1,77 @@
+.resources-page {
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+}
+
+.search-bar {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+
+.search-bar input {
+  width: 100%;
+  max-width: 600px;
+  padding: 10px 15px;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+}
+
+.resources-content {
+  display: flex;
+}
+
+.left-menu {
+  width: 25%;
+  padding-right: 20px;
+}
+
+.left-menu select {
+  width: 100%;
+  padding: 8px;
+  margin-bottom: 15px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+}
+
+.right-resources {
+  width: 75%;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 15px;
+}
+
+.resource-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  border: 1px solid #444;
+  background: #111827;
+  color: #f1f5f9;
+  padding: 15px;
+  border-radius: 8px;
+  position: relative;
+}
+
+.resource-card a {
+  color: #60a5fa;
+  word-break: break-all;
+}
+
+.status-circle {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
+.status-not-attempted { background: #6b7280; }
+.status-solving { background: #3b82f6; }
+.status-solved { background: #22c55e; }
+.status-reviewing { background: #eab308; }
+.status-skipped { background: #f97316; }
+.status-ignored { background: #ef4444; }
+


### PR DESCRIPTION
## Summary
- build resources page with search bar and two-level topic filters
- show resource cards with link and progress status indicator
- add styles for resources layout and status colors

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68a0da18ea288328b31dfa32c96fab73