### PR TITLE
feat: add interactive resource status

### DIFF
--- a/codespace/frontend/src/pages/ResourcesPage.js
+++ b/codespace/frontend/src/pages/ResourcesPage.js
@@ -1,11 +1,143 @@
-import React from 'react';
+import React, { useState } from 'react';
 import NavBar from '../components/NavBar';
+import '../styles/ResourcesPage.css';
+
+const topics = {
+  'Graph Algorithms': ['BFS', 'DFS'],
+  'Dynamic Programming': ['Knapsack', 'LIS'],
+};
+
+const resourcesData = [
+  {
+    id: 1,
+    name: 'BFS Tutorial',
+    link: 'https://example.com/bfs',
+    topic: 'Graph Algorithms',
+    subtopic: 'BFS',
+    status: 'Not Attempted',
+  },
+  {
+    id: 2,
+    name: 'DFS Guide',
+    link: 'https://example.com/dfs',
+    topic: 'Graph Algorithms',
+    subtopic: 'DFS',
+    status: 'Solving',
+  },
+  {
+    id: 3,
+    name: 'Knapsack Article',
+    link: 'https://example.com/knapsack',
+    topic: 'Dynamic Programming',
+    subtopic: 'Knapsack',
+    status: 'Solved',
+  },
+  {
+    id: 4,
+    name: 'LIS Explained',
+    link: 'https://example.com/lis',
+    topic: 'Dynamic Programming',
+    subtopic: 'LIS',
+    status: 'Reviewing',
+  },
+];
 
 function ResourcesPage() {
+  const statuses = ['Not Attempted', 'Solving', 'Solved', 'Reviewing', 'Skipped', 'Ignored'];
+  const [search, setSearch] = useState('');
+  const [selectedTopic, setSelectedTopic] = useState('');
+  const [selectedSubtopic, setSelectedSubtopic] = useState('');
+  const [resources, setResources] = useState(resourcesData);
+  const [openDropdownId, setOpenDropdownId] = useState(null);
+
+  const handleTopicChange = (e) => {
+    setSelectedTopic(e.target.value);
+    setSelectedSubtopic('');
+  };
+
+  const handleStatusChange = (id, status) => {
+    setResources((prev) =>
+      prev.map((res) => (res.id === id ? { ...res, status } : res))
+    );
+    setOpenDropdownId(null);
+  };
+
+  const filteredResources = resources.filter((r) => {
+    const matchesTopic = selectedTopic ? r.topic === selectedTopic : true;
+    const matchesSubtopic = selectedSubtopic ? r.subtopic === selectedSubtopic : true;
+    const matchesSearch = r.name.toLowerCase().includes(search.toLowerCase());
+    return matchesTopic && matchesSubtopic && matchesSearch;
+  });
+
   return (
     <div>
       <NavBar />
-      <h1>Resources Page</h1>
+      <div className="resources-page">
+        <div className="search-bar">
+          <input
+            type="text"
+            placeholder="Search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+        <div className="resources-content">
+          <div className="left-menu">
+            <select value={selectedTopic} onChange={handleTopicChange}>
+              <option value="">All Topics</option>
+              {Object.keys(topics).map((topic) => (
+                <option key={topic} value={topic}>{topic}</option>
+              ))}
+            </select>
+            <select
+              value={selectedSubtopic}
+              onChange={(e) => setSelectedSubtopic(e.target.value)}
+              disabled={!selectedTopic}
+            >
+              <option value="">All Subtopics</option>
+              {selectedTopic && topics[selectedTopic].map((sub) => (
+                <option key={sub} value={sub}>{sub}</option>
+              ))}
+            </select>
+          </div>
+          <div className="right-resources">
+            {filteredResources.map((res) => {
+              const statusClass = `status-${res.status
+                .toLowerCase()
+                .replace(/ /g, '-')}`;
+              return (
+                <div key={res.id} className="resource-card">
+                  <h3>{res.name}</h3>
+                  <a href={res.link} target="_blank" rel="noopener noreferrer">
+                    {res.link}
+                  </a>
+                  <div
+                    className={`status-circle ${statusClass}`}
+                    title={res.status}
+                    onClick={() =>
+                      setOpenDropdownId(
+                        openDropdownId === res.id ? null : res.id
+                      )
+                    }
+                  ></div>
+                  {openDropdownId === res.id && (
+                    <ul className="status-dropdown">
+                      {statuses.map((st) => (
+                        <li
+                          key={st}
+                          onClick={() => handleStatusChange(res.id, st)}
+                        >
+                          {st}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/codespace/frontend/src/styles/ResourcesPage.css
+++ b/codespace/frontend/src/styles/ResourcesPage.css
@@ -1,0 +1,103 @@
+.resources-page {
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+}
+
+.search-bar {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+
+.search-bar input {
+  width: 100%;
+  max-width: 600px;
+  padding: 10px 15px;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+}
+
+.resources-content {
+  display: flex;
+}
+
+.left-menu {
+  width: 25%;
+  padding-right: 20px;
+}
+
+.left-menu select {
+  width: 100%;
+  padding: 8px;
+  margin-bottom: 15px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+}
+
+.right-resources {
+  width: 75%;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 15px;
+}
+
+.resource-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  border: 1px solid #e5e7eb;
+  background: #f9fafb;
+  color: #1f2937;
+  padding: 15px;
+  border-radius: 8px;
+  position: relative;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.resource-card a {
+  color: #2563eb;
+  word-break: break-all;
+}
+
+.status-circle {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  cursor: pointer;
+}
+
+.status-dropdown {
+  position: absolute;
+  top: 40px;
+  right: 10px;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  list-style: none;
+  padding: 5px 0;
+  margin: 0;
+  z-index: 10;
+}
+
+.status-dropdown li {
+  padding: 6px 12px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.status-dropdown li:hover {
+  background: #f3f4f6;
+}
+
+.status-not-attempted { background: #6b7280; }
+.status-solving { background: #3b82f6; }
+.status-solved { background: #22c55e; }
+.status-reviewing { background: #eab308; }
+.status-skipped { background: #f97316; }
+.status-ignored { background: #ef4444; }
+


### PR DESCRIPTION
## Summary
- allow selecting resource progress via clickable status circle with dropdown
- improve card styling with lighter background and shadows
- enlarge status indicator for better visibility

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a0da18ea288328b31dfa32c96fab73