### PR TITLE
feat(resources): add progress dropdown to resource cards

### DIFF
--- a/codespace/frontend/src/styles/ResourcesPage.css
+++ b/codespace/frontend/src/styles/ResourcesPage.css
@@ -60,12 +60,35 @@
 }
 
 .status-circle {
-  width: 14px;
-  height: 14px;
+  width: 24px;
+  height: 24px;
   border-radius: 50%;
   position: absolute;
   top: 10px;
   right: 10px;
+  cursor: pointer;
+}
+
+.status-dropdown {
+  position: absolute;
+  top: 40px;
+  right: 10px;
+  background: #1f2937;
+  border: 1px solid #444;
+  border-radius: 6px;
+  list-style: none;
+  padding: 4px 0;
+  margin: 0;
+  z-index: 10;
+}
+
+.status-dropdown li {
+  padding: 4px 10px;
+  cursor: pointer;
+}
+
+.status-dropdown li:hover {
+  background: #374151;
 }
 
 .status-not-attempted { background: #6b7280; }


### PR DESCRIPTION
## Summary
- enlarge resource status indicators and add dropdown list for progress selection
- persist progress updates in local storage

## Testing
- `cd codespace/frontend && npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a0fad1e744832896e42f77d0e91169