### PR TITLE
Make entire resource card clickable and add status emoji

### DIFF
--- a/codespace/frontend/src/pages/ResourcesPage.js
+++ b/codespace/frontend/src/pages/ResourcesPage.js
@@ -91,20 +91,35 @@ function ResourcesPage() {
               const statusClass = `status-${res.status.toLowerCase().replace(/ /g, '-')}`;
               const isOpen = openStatusId === res.id;
               return (
-                <div key={res.id} className="resource-card">
-                  <h3>{res.name}</h3>
-                  <a href={res.link} target="_blank" rel="noopener noreferrer">{res.link}</a>
+                <div
+                  key={res.id}
+                  className="resource-card"
+                  onClick={() => window.open(res.link, '_blank', 'noopener,noreferrer')}
+                >
+                  <div className="resource-header">
+                    <span
+                      className={`status-emoji ${statusClass}`}
+                      role="img"
+                      aria-label={res.status}
+                    >●</span>
+                    <h3>{res.name}</h3>
+                  </div>
+                  <p className="resource-link">{res.link}</p>
                   <div
                     className={`status-circle ${statusClass}`}
                     title={res.status}
-                    onClick={() => setOpenStatusId(isOpen ? null : res.id)}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setOpenStatusId(isOpen ? null : res.id);
+                    }}
                   ></div>
                   {isOpen && (
-                    <ul className="status-dropdown">
+                    <ul className="status-dropdown" onClick={(e) => e.stopPropagation()}>
                       {statusOptions.map((status) => (
                         <li
                           key={status}
-                          onClick={() => {
+                          onClick={(e) => {
+                            e.stopPropagation();
                             updateStatus(res.id, status);
                             setOpenStatusId(null);
                           }}

--- a/codespace/frontend/src/styles/ResourcesPage.css
+++ b/codespace/frontend/src/styles/ResourcesPage.css
@@ -52,11 +52,19 @@
   padding: 15px;
   border-radius: 8px;
   position: relative;
+  cursor: pointer;
 }
 
-.resource-card a {
+.resource-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.resource-link {
   color: #60a5fa;
   word-break: break-all;
+  margin: 4px 0 0;
 }
 
 .status-circle {
@@ -97,4 +105,15 @@
 .status-reviewing { background: #eab308; }
 .status-skipped { background: #f97316; }
 .status-ignored { background: #ef4444; }
+
+.status-emoji {
+  font-size: 1.2em;
+}
+
+.status-emoji.status-not-attempted { color: #6b7280; }
+.status-emoji.status-solving { color: #3b82f6; }
+.status-emoji.status-solved { color: #22c55e; }
+.status-emoji.status-reviewing { color: #eab308; }
+.status-emoji.status-skipped { color: #f97316; }
+.status-emoji.status-ignored { color: #ef4444; }
 


### PR DESCRIPTION
## Summary
- Make resource cards open their link when anywhere in the card is clicked
- Display status-colored emoji next to each resource name

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a0fee8395c832886e766516ba9a37c