### PR TITLE
feat: add emoji indicators for resource status

### DIFF
--- a/codespace/frontend/src/pages/ResourcesPage.js
+++ b/codespace/frontend/src/pages/ResourcesPage.js
@@ -8,12 +8,12 @@ const topics = {
 };
 
 const statusOptions = [
-  'Not Attempted',
-  'Solving',
-  'Solved',
-  'Reviewing',
-  'Skipped',
-  'Ignored',
+  { value: 'Not Attempted', emoji: '⏳' },
+  { value: 'Solving', emoji: '🧠' },
+  { value: 'Solved', emoji: '👨‍💻' },
+  { value: 'Reviewing', emoji: '🔍' },
+  { value: 'Skipped', emoji: '⏭️' },
+  { value: 'Ignored', emoji: '🚫' },
 ];
 
 const initialResources = [
@@ -97,11 +97,6 @@ function ResourcesPage() {
                   onClick={() => window.open(res.link, '_blank', 'noopener,noreferrer')}
                 >
                   <div className="resource-header">
-                    <span
-                      className={`status-emoji ${statusClass}`}
-                      role="img"
-                      aria-label={res.status}
-                    >●</span>
                     <h3>{res.name}</h3>
                   </div>
                   <p className="resource-link">{res.link}</p>
@@ -115,16 +110,25 @@ function ResourcesPage() {
                   ></div>
                   {isOpen && (
                     <ul className="status-dropdown" onClick={(e) => e.stopPropagation()}>
-                      {statusOptions.map((status) => (
+                      {statusOptions.map(({ value, emoji }) => (
                         <li
-                          key={status}
+                          key={value}
                           onClick={(e) => {
                             e.stopPropagation();
-                            updateStatus(res.id, status);
+                            updateStatus(res.id, value);
                             setOpenStatusId(null);
                           }}
                         >
-                          {status}
+                          <span
+                            className={`status-emoji status-${value
+                              .toLowerCase()
+                              .replace(/ /g, '-')}`}
+                            role="img"
+                            aria-label={value}
+                          >
+                            {emoji}
+                          </span>
+                          {value}
                         </li>
                       ))}
                     </ul>

--- a/codespace/frontend/src/styles/ResourcesPage.css
+++ b/codespace/frontend/src/styles/ResourcesPage.css
@@ -93,6 +93,9 @@
 .status-dropdown li {
   padding: 4px 10px;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .status-dropdown li:hover {


### PR DESCRIPTION
## Summary
- show color-coded emoji next to each status in resource progress menu
- remove colored dot beside resource names
- style status dropdown items for emoji and text alignment

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68a1011897208328ac4dbbf367e50492