### PR TITLE
fix: remove background color behind status emojis

### DIFF
--- a/codespace/frontend/src/styles/ResourcesPage.css
+++ b/codespace/frontend/src/styles/ResourcesPage.css
@@ -102,15 +102,16 @@
   background: #374151;
 }
 
-.status-not-attempted { background: #6b7280; }
-.status-solving { background: #3b82f6; }
-.status-solved { background: #22c55e; }
-.status-reviewing { background: #eab308; }
-.status-skipped { background: #f97316; }
-.status-ignored { background: #ef4444; }
+.status-circle.status-not-attempted { background: #6b7280; }
+.status-circle.status-solving { background: #3b82f6; }
+.status-circle.status-solved { background: #22c55e; }
+.status-circle.status-reviewing { background: #eab308; }
+.status-circle.status-skipped { background: #f97316; }
+.status-circle.status-ignored { background: #ef4444; }
 
 .status-emoji {
   font-size: 1.2em;
+  background: none;
 }
 
 .status-emoji.status-not-attempted { color: #6b7280; }


### PR DESCRIPTION
## Summary
- scope status colors to status-circle to avoid affecting emojis
- ensure emojis render without unwanted background

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a102a8c5c483288f58733301df2267