### PR TITLE
Move resources to database

### DIFF
--- a/codespace/server/app.js
+++ b/codespace/server/app.js
@@ -11,6 +11,7 @@ const roomsRoute = require("./routes/rooms");
 const contestsRoute = require("./routes/contests")
 const authMiddleware = require("./middleware/authMiddleware")
 const usersRoute = require("./routes/users")
+const resourcesRoute = require("./routes/resources")
 const rateLimit = require('express-rate-limit');
 
 const app = express();
@@ -39,6 +40,7 @@ app.use('/api',api1)
 app.use('/api/contests',contestsRoute)
 app.use('/api/rooms', authMiddleware, roomsRoute)
 app.use('/api/users', usersRoute)
+app.use('/api/resources', resourcesRoute)
 app.use('/test',test)
 app.use('/submit',submit)
 

--- a/codespace/server/model/resourceModel.js
+++ b/codespace/server/model/resourceModel.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const resourceSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  link: { type: String, required: true },
+  topic: { type: String, required: true },
+  subtopic: { type: String, required: true },
+  status: { type: String, default: 'Not Attempted' }
+});
+
+module.exports = mongoose.model('Resource', resourceSchema);

--- a/codespace/server/routes/resources.js
+++ b/codespace/server/routes/resources.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const Resource = require('../model/resourceModel');
+
+const router = express.Router();
+const url = process.env.MONGODB_URI || 'mongodb://localhost:27017/graduation_project';
+
+mongoose.connect(url);
+
+router.get('/', async (req, res) => {
+  try {
+    const resources = await Resource.find();
+    res.json(resources);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch resources' });
+  }
+});
+
+router.patch('/:id', async (req, res) => {
+  try {
+    const { status, name, link, topic, subtopic } = req.body;
+    const update = {};
+    if (status !== undefined) update.status = status;
+    if (name !== undefined) update.name = name;
+    if (link !== undefined) update.link = link;
+    if (topic !== undefined) update.topic = topic;
+    if (subtopic !== undefined) update.subtopic = subtopic;
+
+    const resource = await Resource.findByIdAndUpdate(req.params.id, update, { new: true });
+    res.json(resource);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to update resource' });
+  }
+});
+
+module.exports = router;

--- a/codespace/server/scripts/seedResources.js
+++ b/codespace/server/scripts/seedResources.js
@@ -1,0 +1,27 @@
+require('dotenv').config();
+const mongoose = require('mongoose');
+const Resource = require('../model/resourceModel');
+
+const url = process.env.MONGODB_URI || 'mongodb://localhost:27017/graduation_project';
+
+const resources = [
+  { name: 'BFS Tutorial', link: 'https://example.com/bfs', topic: 'Graph Algorithms', subtopic: 'BFS', status: 'Not Attempted' },
+  { name: 'DFS Guide', link: 'https://example.com/dfs', topic: 'Graph Algorithms', subtopic: 'DFS', status: 'Solving' },
+  { name: 'Knapsack Article', link: 'https://example.com/knapsack', topic: 'Dynamic Programming', subtopic: 'Knapsack', status: 'Solved' },
+  { name: 'LIS Explained', link: 'https://example.com/lis', topic: 'Dynamic Programming', subtopic: 'LIS', status: 'Reviewing' }
+];
+
+async function seed() {
+  try {
+    await mongoose.connect(url);
+    await Resource.deleteMany({});
+    await Resource.insertMany(resources);
+    console.log('Resources seeded');
+    await mongoose.disconnect();
+  } catch (err) {
+    console.error('Seeding failed', err);
+    process.exit(1);
+  }
+}
+
+seed();


### PR DESCRIPTION
## Summary
- Add Mongoose model and API routes for learning resources
- Seed database with initial learning resources
- Fetch resources from backend and persist status updates

## Testing
- `npm test` (server) *(fails: Missing script "test")*
- `CI=true npm test -- --watchAll=false` (frontend) *(fails: No tests found)*
- `node codespace/server/scripts/seedResources.js` *(fails: connect ECONNREFUSED ::1:27017)*

------
https://chatgpt.com/codex/tasks/task_e_68a1040704488328bf4ead99f367ea47