### PR TITLE
Add ability to create new resources

### DIFF
--- a/codespace/frontend/src/pages/ResourcesPage.js
+++ b/codespace/frontend/src/pages/ResourcesPage.js
@@ -24,6 +24,13 @@ function ResourcesPage() {
   const [selectedSubtopic, setSelectedSubtopic] = useState('');
   const [resources, setResources] = useState([]);
   const [openStatusId, setOpenStatusId] = useState(null);
+  const [showForm, setShowForm] = useState(false);
+  const [formData, setFormData] = useState({
+    name: '',
+    link: '',
+    topic: '',
+    subtopic: '',
+  });
 
   useEffect(() => {
     const fetchResources = async () => {
@@ -40,6 +47,27 @@ function ResourcesPage() {
   const handleTopicChange = (e) => {
     setSelectedTopic(e.target.value);
     setSelectedSubtopic('');
+  };
+
+  const handleFormChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+      ...(name === 'topic' ? { subtopic: '' } : {}),
+    }));
+  };
+
+  const addResource = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await axios.post(`${BACKEND_URL}/api/resources`, formData);
+      setResources((prev) => [...prev, res.data]);
+      setFormData({ name: '', link: '', topic: '', subtopic: '' });
+      setShowForm(false);
+    } catch (err) {
+      console.error('Failed to add resource', err);
+    }
   };
 
   const updateStatus = async (id, status) => {
@@ -74,6 +102,51 @@ function ResourcesPage() {
         </div>
         <div className="resources-content">
           <div className="left-menu">
+            <button onClick={() => setShowForm(!showForm)}>New</button>
+            {showForm && (
+              <form className="add-resource-form" onSubmit={addResource}>
+                <input
+                  type="text"
+                  name="name"
+                  placeholder="Name"
+                  value={formData.name}
+                  onChange={handleFormChange}
+                  required
+                />
+                <input
+                  type="text"
+                  name="link"
+                  placeholder="Link"
+                  value={formData.link}
+                  onChange={handleFormChange}
+                  required
+                />
+                <select
+                  name="topic"
+                  value={formData.topic}
+                  onChange={handleFormChange}
+                  required
+                >
+                  <option value="">Select Topic</option>
+                  {Object.keys(topics).map((topic) => (
+                    <option key={topic} value={topic}>{topic}</option>
+                  ))}
+                </select>
+                <select
+                  name="subtopic"
+                  value={formData.subtopic}
+                  onChange={handleFormChange}
+                  disabled={!formData.topic}
+                  required
+                >
+                  <option value="">Select Subtopic</option>
+                  {formData.topic && topics[formData.topic].map((sub) => (
+                    <option key={sub} value={sub}>{sub}</option>
+                  ))}
+                </select>
+                <button type="submit">Add</button>
+              </form>
+            )}
             <select value={selectedTopic} onChange={handleTopicChange}>
               <option value="">All Topics</option>
               {Object.keys(topics).map((topic) => (

--- a/codespace/frontend/src/styles/ResourcesPage.css
+++ b/codespace/frontend/src/styles/ResourcesPage.css
@@ -35,6 +35,32 @@
   border: 1px solid #ccc;
 }
 
+.left-menu button {
+  width: 100%;
+  padding: 8px;
+  margin-bottom: 15px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  background: #1f2937;
+  color: #f1f5f9;
+  cursor: pointer;
+}
+
+.add-resource-form input,
+.add-resource-form select,
+.add-resource-form button {
+  width: 100%;
+  padding: 8px;
+  margin-bottom: 10px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+}
+
+.add-resource-form button {
+  background: #3b82f6;
+  color: #fff;
+}
+
 .right-resources {
   width: 75%;
   display: grid;

--- a/codespace/server/routes/resources.js
+++ b/codespace/server/routes/resources.js
@@ -16,6 +16,17 @@ router.get('/', async (req, res) => {
   }
 });
 
+router.post('/', async (req, res) => {
+  try {
+    const { name, link, topic, subtopic } = req.body;
+    const resource = new Resource({ name, link, topic, subtopic });
+    await resource.save();
+    res.status(201).json(resource);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to create resource' });
+  }
+});
+
 router.patch('/:id', async (req, res) => {
   try {
     const { status, name, link, topic, subtopic } = req.body;


### PR DESCRIPTION
## Summary
- add POST endpoint for creating resources
- add New button and creation form on Resources page
- style resource creation UI

## Testing
- `npm test -- --watchAll=false --passWithNoTests` (frontend)
- `npm test` (server, fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a105a0ff888328817cb1879be251a1