### PR TITLE
Send proper responses for problem routes

### DIFF
--- a/codespace/server/routes/api.js
+++ b/codespace/server/routes/api.js
@@ -119,9 +119,11 @@ router.post('/new', async (req,res) => {
     // store test data locally
     saveFile(`${id}`, 'input.txt', main_tests);
     saveFile(`${id}`, 'output.txt', expected_output);
+    res.status(201).json({ message: 'Problem created' });
   }
   catch(error){
     console.error(error);
+    res.status(500).json({ error: 'Failed to create problem' });
   }
 
 })
@@ -215,6 +217,7 @@ router.post('/get-test-package', async (req,res) => {
   }
   catch(error){
     console.error(error);
+    res.status(500).json({ error: 'Error fetching test package' });
   }
 })
 


### PR DESCRIPTION
## Summary
- send success 201 response when creating a new problem and handle failures with 500
- add HTTP 500 error handling for test package retrieval

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a1bccdf9488328a0e505166377e7ec