### PR TITLE
Add authorization token to submission requests

### DIFF
--- a/codespace/frontend/src/components/TextBox.js
+++ b/codespace/frontend/src/components/TextBox.js
@@ -3,6 +3,7 @@ import axios from 'axios';
 import '../styles/App.css';
 import CodeMirror from '@uiw/react-codemirror';
 import { cpp } from '@codemirror/lang-cpp';
+import { useNavigate } from 'react-router-dom';
 import BACKEND_URL from '../config';
 
 // Replace with the URL you want to send the request to
@@ -16,6 +17,7 @@ export default function TextBox({socketRef,currentProbId}) {
     const [inputvalue, setInputvalue] = useState('');
     const [outputvalue, setOutputvalue] = useState('');
     const [color, setColor] = useState('black');
+    const navigate = useNavigate();
 
     const SocketEmit = useCallback((channel,msg) => {
         if(socketRef.current){
@@ -77,10 +79,17 @@ export default function TextBox({socketRef,currentProbId}) {
                 code: textvalue,
                 problem_id: currentProbId
             };
-            const response = await axios.post(submitUrl, requestData);
+            const token = localStorage.getItem('token');
+            const response = await axios.post(submitUrl, requestData, {
+                headers: { Authorization: `Bearer ${token}` }
+            });
             setOutputvalue(response.data);
         }
         catch(error){
+            if (error.response && error.response.status === 401) {
+                navigate('/login');
+                return;
+            }
             setOutputvalue(error.message);
         }
     }


### PR DESCRIPTION
## Summary
- Include `useNavigate` in TextBox to handle redirects
- Read auth token from localStorage and attach as `Authorization: Bearer` for submissions
- Redirect users to `/login` if submission returns 401

## Testing
- `cd codespace/frontend && npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68a32ad4362083288b222af00f8dae10