### PR TITLE
Add problem model and DB-backed problem retrieval

### DIFF
--- a/codespace/frontend/src/pages/ProblemDetailPage.js
+++ b/codespace/frontend/src/pages/ProblemDetailPage.js
@@ -13,10 +13,19 @@ function ProblemDetailPage() {
   useEffect(() => {
     async function fetchProblem() {
       try {
-        const res = await axios.get(`${BACKEND_URL}/api/parse_problem/${id}`);
+        const res = await axios.get(`${BACKEND_URL}/api/problems/${id}`);
         setProblem(res.data);
       } catch (err) {
-        console.error('Error fetching problem:', err);
+        if (err.response && err.response.status === 404) {
+          try {
+            const scrapeRes = await axios.get(`${BACKEND_URL}/api/parse_problem/${id}`);
+            setProblem(scrapeRes.data);
+          } catch (scrapeErr) {
+            console.error('Error scraping problem:', scrapeErr);
+          }
+        } else {
+          console.error('Error fetching problem:', err);
+        }
       }
     }
     fetchProblem();
@@ -27,20 +36,31 @@ function ProblemDetailPage() {
       <NavBar />
       {problem ? (
         <div>
-          <h1>{problem.title}</h1>
+          <h1>{problem.problem_name || problem.title}</h1>
           <div dangerouslySetInnerHTML={{ __html: problem.statement }} />
           <h2>Sample Tests</h2>
-          {problem.sample_input && problem.sample_outputs && (
+          {problem.sinput && problem.soutput ? (
             <ul>
-              {problem.sample_input.map((input, idx) => (
-                <li key={idx}>
-                  <p>Input:</p>
-                  <pre>{input}</pre>
-                  <p>Output:</p>
-                  <pre>{problem.sample_outputs[idx]}</pre>
-                </li>
-              ))}
+              <li>
+                <p>Input:</p>
+                <pre>{problem.sinput}</pre>
+                <p>Output:</p>
+                <pre>{problem.soutput}</pre>
+              </li>
             </ul>
+          ) : (
+            problem.sample_input && problem.sample_outputs && (
+              <ul>
+                {problem.sample_input.map((input, idx) => (
+                  <li key={idx}>
+                    <p>Input:</p>
+                    <pre>{input}</pre>
+                    <p>Output:</p>
+                    <pre>{problem.sample_outputs[idx]}</pre>
+                  </li>
+                ))}
+              </ul>
+            )
           )}
           <h2>Solve</h2>
           <TextBox socketRef={socketRef} currentProbId={id} />

--- a/codespace/server/model/problemModel.js
+++ b/codespace/server/model/problemModel.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const problemSchema = new mongoose.Schema({
+  id: String,
+  problem_name: String,
+  statement: String,
+  sinput: String,
+  soutput: String,
+});
+
+module.exports = mongoose.model('Problem Packages', problemSchema);

--- a/codespace/server/routes/api.js
+++ b/codespace/server/routes/api.js
@@ -9,22 +9,7 @@ const {scrapingQueue} = require('../jobs/webScrapingWorker')
 const { saveFile, getTestData } = require('../controllers/fileStorage');
 const expire_time = 3600;
 
-const ProblemSchema = new mongoose.Schema({
-  id: String,
-  problem_name:  String,
-  statement:  String,
-  sinput: String,
-  soutput: String,
-});
-
-const testsSchema = new mongoose.Schema({
-  id: String,
-  main_tests: String,
-  expected_output: String,
-});
-
-const problem_model = mongoose.model('Problem Packages',ProblemSchema);
-// const tests_model = mongoose.model('Test Packages',testsSchema);
+const problem_model = require('../model/problemModel');
 mongoose.connect(url).catch(err => {
   console.error('Failed to connect to MongoDB:', err.message);
 });
@@ -155,6 +140,20 @@ router.get('/problem-list',async (req,res) => {
     res.status(500).send("sowwie,error fetching problems");
   }
 })
+
+router.get('/problems/:id', async (req, res) => {
+  try {
+    const problem = await problem_model.findOne({ id: req.params.id });
+    if (problem) {
+      res.json(problem);
+    } else {
+      res.status(404).json({ error: 'Problem not found' });
+    }
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ error: 'Error fetching problem' });
+  }
+});
 
 router.get('/parse_problem/:param',async (req,res) => {
   console.log("who called me");


### PR DESCRIPTION
## Summary
- add Problem schema/model and move definition out of routes
- expose GET /api/problems/:id to fetch problem data from MongoDB
- load problem details from DB in frontend with scrape fallback

## Testing
- `cd codespace/server && npm test` *(fails: Missing script)*
- `cd codespace/frontend && npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a32afbe9248328aecd3469e450fc84