### PR TITLE
Remove token storage on signup

### DIFF
--- a/codespace/frontend/src/pages/SignupPage.js
+++ b/codespace/frontend/src/pages/SignupPage.js
@@ -29,7 +29,6 @@ function SignupPage() {
         setError(data.message || 'Signup failed');
         return;
       }
-      localStorage.setItem('token', data.token);
       navigate('/login');
     } catch (err) {
       setError('Signup failed');


### PR DESCRIPTION
## Summary
- Ensure signup redirects to login without storing a JWT

## Testing
- `npm test --prefix codespace/frontend -- --watchAll=false` *(fails: No tests found, exiting with code 1)*
- `npm test --prefix codespace/server` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a3309c7b208328b4f69ee8a93f637f