### PR TITLE
Mount Docker socket for server container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
   server:
     build: ./codespace/server
     restart: unless-stopped
+    user: root
     environment:
       - MONGODB_URI=${MONGODB_URI}
       - TEST_DATA_DIR=${TEST_DATA_DIR}
@@ -20,6 +21,8 @@ services:
       - REDIS_URL=${REDIS_URL}
     ports: [6909:6909]
     depends_on: [mongo, redis]
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
   frontend:
     build: ./codespace/frontend
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- allow server container to access host Docker daemon by mounting `/var/run/docker.sock`
- run server as root so it can access the mounted socket

## Testing
- `docker compose config` *(fails: command not found)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a33c21653083289ea8b25d8380ceb2