### PR TITLE
chore: install docker cli in server image

### DIFF
--- a/codespace/server/Dockerfile
+++ b/codespace/server/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:18-alpine
+RUN apk add --no-cache docker-cli
 WORKDIR /app
 COPY package*.json ./
 RUN npm install --production


### PR DESCRIPTION
## Summary
- install docker CLI in server image to enable Docker-based tasks

## Testing
- `docker-compose build server` *(fails: Error while fetching server API version: FileNotFoundError)*
- `docker-compose up` *(fails: Error while fetching server API version: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68a34843eaf48328b62fe0f8da305260