### PR TITLE
Fix unwanted page scroll

### DIFF
--- a/codespace/frontend/src/index.js
+++ b/codespace/frontend/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-// import './styles/index.css';
+import './styles/index.css';
 import App from './App';
 import ProblemDetailPage from './pages/ProblemDetailPage';
 import process from 'process';

--- a/codespace/frontend/src/styles/index.css
+++ b/codespace/frontend/src/styles/index.css
@@ -1,10 +1,18 @@
 body {
   margin: 0;
+  overflow: hidden;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+/* Include padding and border in element width/height calculations */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
 code {


### PR DESCRIPTION
## Summary
- import global stylesheet to normalize body spacing
- hide body overflow and enforce border-box sizing to stop subtle page scrolling

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a4ac4040d88328bd0a0ab3d4a5556e