### PR TITLE
feat: add room-wide chat channel

### DIFF
--- a/codespace/frontend/src/components/ChatBox.js
+++ b/codespace/frontend/src/components/ChatBox.js
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from 'react';
+import '../styles/ChatBox.css';
+
+export default function ChatBox({ socketRef, username }) {
+  const [message, setMessage] = useState('');
+  const [messages, setMessages] = useState([]);
+
+  useEffect(() => {
+    if (socketRef.current) {
+      const handler = (payload) => {
+        setMessages((prev) => [...prev, { username: payload.username, msg: payload.msg }]);
+      };
+      socketRef.current.on('receive message', handler);
+      return () => socketRef.current.off('receive message', handler);
+    }
+  }, [socketRef]);
+
+  const sendMessage = (e) => {
+    e.preventDefault();
+    const trimmed = message.trim();
+    if (!trimmed) return;
+    if (socketRef.current) {
+      socketRef.current.emit('send-message', { msg: trimmed });
+    }
+    setMessage('');
+  };
+
+  return (
+    <div className="chat-container">
+      <div className="chat-messages">
+        {messages.map((m, idx) => (
+          <div key={idx} className="chat-message">
+            <strong>{m.username}: </strong>{m.msg}
+          </div>
+        ))}
+      </div>
+      <form className="chat-input" onSubmit={sendMessage}>
+        <input
+          type="text"
+          placeholder="Type a message..."
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+        />
+        <button type="submit">Send</button>
+      </form>
+    </div>
+  );
+}

--- a/codespace/frontend/src/components/Room.js
+++ b/codespace/frontend/src/components/Room.js
@@ -5,6 +5,7 @@ import { useNavigate } from 'react-router-dom';
 import MiniDrawer from './SideDrawer';
 import Split from 'react-split';
 import MainLHS from './LHS/MainLHS';
+import ChatBox from './ChatBox';
 import io from 'socket.io-client';
 import SimplePeer from 'simple-peer';
 import BACKEND_URL from '../config';
@@ -101,11 +102,6 @@ export default function Room() {
     useEffect(() => {
       socketRef.current = io(BACKEND_URL, { transports: ['websocket'] });
 
-      socketRef.current.on('receive message', (payload) => {
-        console.log(`I am ${userid}`);
-        console.log(payload.msg);
-      });
-
       // previous implementation relied on an 'all users' broadcast which
       // could fire before a microphone stream was available, leaving new
       // participants without peers. The logic has moved to the
@@ -199,37 +195,47 @@ export default function Room() {
       return (
         <div className="editor-background">
         <button className="leave-room-button" onClick={leaveRoom}>Leave Room</button>
+        <MiniDrawer toggleMic={toggleMic} roomid={roomid} members={members} isMicOn={isMicOn}>
         <div className='main'>
-              <Split
-                  sizes={[20, 80]}
-                minSize={200}
-                maxSize={1000}
-                direction="horizontal"
-                gutterSize={10}
-                gutterAlign="center"
-                className="split"
-                gutter={(index, direction) => {
-                    const gutter = document.createElement('div');
-                    gutter.className = `gutter gutter-${direction}`;
-                    return gutter;
-                }}
+            <Split
+              direction='vertical'
+              sizes={[80, 20]}
+              minSize={100}
+              className='vertical-split'
             >
-                <div className="LHS-container">
+              <div className='top-pane'>
+                <Split
+                  sizes={[40, 60]}
+                  minSize={200}
+                  maxSize={1000}
+                  direction="horizontal"
+                  gutterSize={10}
+                  gutterAlign="center"
+                  className="split"
+                  gutter={(index, direction) => {
+                      const gutter = document.createElement('div');
+                      gutter.className = `gutter gutter-${direction}`;
+                      return gutter;
+                  }}
+                >
+                  <div className="LHS-container">
                     <MainLHS socketRef={socketRef} currentProbId={currentProbId} setCurrentProb={setCurrentProb} />
-                </div>
-                <div className="RHS-container">
+                  </div>
+                  <div className="RHS-container">
                     <TextBox socketRef={socketRef} currentProbId={currentProbId} />
-                </div>
-            </Split>
-              <MiniDrawer toggleMic={toggleMic} roomid={roomid} members={members} isMicOn={isMicOn} />
-            {/* <AudioRecorder socket={socket} username={username} roomid={roomid}/> */}
-            <Container>
-                <StyledVideo muted ref={userVideo} autoPlay playsInline />
-                {peers.map((peer, index) => (
+                  </div>
+                </Split>
+                <Container>
+                  <StyledVideo muted ref={userVideo} autoPlay playsInline />
+                  {peers.map((peer, index) => (
                     <Video key={index} peer={peer} />
-                ))}
-            </Container>
+                  ))}
+                </Container>
+              </div>
+              <ChatBox socketRef={socketRef} username={username} />
+            </Split>
         </div>
+        </MiniDrawer>
         </div>
     );
 };

--- a/codespace/frontend/src/components/SideDrawer.js
+++ b/codespace/frontend/src/components/SideDrawer.js
@@ -85,7 +85,7 @@ const MemberCard = ({ id, member }) => {
   );
 };
 
-export default function MiniDrawer({ toggleMic, roomid, members = [], isMicOn }) {
+export default function MiniDrawer({ toggleMic, roomid, members = [], isMicOn, children }) {
   const theme = useTheme();
   const [open, setOpen] = React.useState(false);
   const [copied, setCopied] = React.useState(false);
@@ -105,7 +105,7 @@ export default function MiniDrawer({ toggleMic, roomid, members = [], isMicOn })
   };
 
   return (
-    <div>
+    <div style={{ display: 'flex' }}>
       <Drawer variant="permanent" open={open}>
         <div style={{display:'flex', flexDirection:'column', height:'100%'}}>
           <IconButton
@@ -149,7 +149,7 @@ export default function MiniDrawer({ toggleMic, roomid, members = [], isMicOn })
         </div>
       </Drawer>
       <ContentContainer open={open} theme={theme}>
-        {/* Your main content goes here */}
+        {children}
       </ContentContainer>
     </div>
   );

--- a/codespace/frontend/src/styles/ChatBox.css
+++ b/codespace/frontend/src/styles/ChatBox.css
@@ -1,0 +1,43 @@
+.chat-container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: #ffffff;
+  border-top: 1px solid #ddd;
+}
+
+.chat-messages {
+  flex: 1;
+  padding: 0.5rem;
+  overflow-y: auto;
+}
+
+.chat-message {
+  margin-bottom: 0.25rem;
+  word-break: break-word;
+}
+
+.chat-input {
+  display: flex;
+  border-top: 1px solid #ddd;
+}
+
+.chat-input input {
+  flex: 1;
+  padding: 0.5rem;
+  border: none;
+  outline: none;
+}
+
+.chat-input button {
+  padding: 0 1rem;
+  border: none;
+  background: #1976d2;
+  color: #fff;
+  cursor: pointer;
+}
+
+.chat-input button:hover {
+  background: #115293;
+}

--- a/codespace/frontend/src/styles/RoomPage.css
+++ b/codespace/frontend/src/styles/RoomPage.css
@@ -18,6 +18,22 @@
   height: 100%;
 }
 
+.vertical-split {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.top-pane {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.top-pane .split {
+  flex: 1;
+}
+
 .LHS-container,
 .RHS-container {
   background: #ffffff;

--- a/codespace/server/app.js
+++ b/codespace/server/app.js
@@ -102,7 +102,11 @@ io.on('connection', (socket) => {
 
     socket.on('send-message', async (payload) => {
         await addMessage(socket.roomid, socket.userid, socket.username, payload.msg);
-        io.to(socket.roomid).emit('receive message',{msg: payload.msg});
+        io.to(socket.roomid).emit('receive message', {
+            userid: socket.userid,
+            username: socket.username,
+            msg: payload.msg
+        });
     })
 
     socket.on('sending offer', (payload) => {


### PR DESCRIPTION
## Summary
- support username broadcast for chat messages on backend
- make side drawer flexible and wrap page content
- add bottom chat panel in room view with corresponding styles

## Testing
- `cd codespace/frontend && npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a4b0186c208328ab6fb7cab82db838