### PR TITLE
Improve room chat visibility and styling

### DIFF
--- a/codespace/frontend/src/components/ChatBox.js
+++ b/codespace/frontend/src/components/ChatBox.js
@@ -30,7 +30,9 @@ export default function ChatBox({ socketRef, username }) {
       <div className="chat-messages">
         {messages.map((m, idx) => (
           <div key={idx} className="chat-message">
-            <strong>{m.username}: </strong>{m.msg}
+            <span className="chat-emoji" role="img" aria-label="user">🙂</span>
+            <span className="chat-user">{m.username}:</span>
+            <span className="chat-text">{m.msg}</span>
           </div>
         ))}
       </div>

--- a/codespace/frontend/src/styles/ChatBox.css
+++ b/codespace/frontend/src/styles/ChatBox.css
@@ -3,8 +3,8 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  background: #ffffff;
-  border-top: 1px solid #ddd;
+  background: #f5f5f5;
+  border-top: 2px solid #ddd;
 }
 
 .chat-messages {
@@ -14,13 +14,33 @@
 }
 
 .chat-message {
+  display: flex;
+  align-items: center;
   margin-bottom: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  background: #ffffff;
+  border-radius: 6px;
   word-break: break-word;
+}
+
+.chat-emoji {
+  margin-right: 0.5rem;
+}
+
+.chat-user {
+  margin-right: 0.25rem;
+  font-weight: 600;
+  color: #1976d2;
+}
+
+.chat-text {
+  color: #333;
 }
 
 .chat-input {
   display: flex;
-  border-top: 1px solid #ddd;
+  border-top: 1px solid #ccc;
+  background: #fff;
 }
 
 .chat-input input {
@@ -28,6 +48,7 @@
   padding: 0.5rem;
   border: none;
   outline: none;
+  background: #fff;
 }
 
 .chat-input button {


### PR DESCRIPTION
## Summary
- tweak chat container colors and layout for visibility
- style individual messages with sender name and placeholder emoji

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a4b44e37a08328a61206d2276a9f90