### PR TITLE
Ensure chat box stays visible beneath editor

### DIFF
--- a/codespace/frontend/src/styles/ChatBox.css
+++ b/codespace/frontend/src/styles/ChatBox.css
@@ -5,6 +5,8 @@
   flex-direction: column;
   background: #f5f5f5;
   border-top: 2px solid #ddd;
+  position: relative;
+  z-index: 10;
 }
 
 .chat-messages {

--- a/codespace/frontend/src/styles/RoomPage.css
+++ b/codespace/frontend/src/styles/RoomPage.css
@@ -5,13 +5,13 @@
   background: linear-gradient(135deg, #e3f2fd, #ffffff);
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow: visible;
   transition: background 0.5s ease;
 }
 
 .editor-background .main {
   flex: 1;
-  overflow: hidden;
+  overflow: auto;
 }
 
 .split {


### PR DESCRIPTION
## Summary
- allow the main editor area to scroll and not hide content
- raise chat container's stacking context so it displays in front of other panes

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b85318648328922bf6009a9b7a35