### PR TITLE
Restructure problem page with separated problem, editor, and chat sections

### DIFF
--- a/codespace/frontend/src/pages/ProblemDetailPage.js
+++ b/codespace/frontend/src/pages/ProblemDetailPage.js
@@ -1,14 +1,18 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import axios from 'axios';
+import io from 'socket.io-client';
 import NavBar from '../components/NavBar';
 import TextBox from '../components/TextBox';
+import ChatBox from '../components/ChatBox';
 import BACKEND_URL from '../config';
+import '../styles/ProblemDetailPage.css';
 
 function ProblemDetailPage() {
   const { id } = useParams();
   const [problem, setProblem] = useState(null);
   const socketRef = useRef(null);
+  const username = localStorage.getItem('username');
 
   useEffect(() => {
     async function fetchProblem() {
@@ -31,39 +35,54 @@ function ProblemDetailPage() {
     fetchProblem();
   }, [id]);
 
+  useEffect(() => {
+    socketRef.current = io(BACKEND_URL, { transports: ['websocket'] });
+    return () => {
+      if (socketRef.current) {
+        socketRef.current.disconnect();
+      }
+    };
+  }, []);
+
   return (
     <div>
       <NavBar />
       {problem ? (
-        <div>
-          <h1>{problem.problem_name || problem.title}</h1>
-          <div dangerouslySetInnerHTML={{ __html: problem.statement }} />
-          <h2>Sample Tests</h2>
-          {problem.sinput && problem.soutput ? (
-            <ul>
-              <li>
-                <p>Input:</p>
-                <pre>{problem.sinput}</pre>
-                <p>Output:</p>
-                <pre>{problem.soutput}</pre>
-              </li>
-            </ul>
-          ) : (
-            problem.sample_input && problem.sample_outputs && (
+        <div className="problem-detail-container">
+          <div className="problem-view">
+            <h1>{problem.problem_name || problem.title}</h1>
+            <div dangerouslySetInnerHTML={{ __html: problem.statement }} />
+            <h2>Sample Tests</h2>
+            {problem.sinput && problem.soutput ? (
               <ul>
-                {problem.sample_input.map((input, idx) => (
-                  <li key={idx}>
-                    <p>Input:</p>
-                    <pre>{input}</pre>
-                    <p>Output:</p>
-                    <pre>{problem.sample_outputs[idx]}</pre>
-                  </li>
-                ))}
+                <li>
+                  <p>Input:</p>
+                  <pre>{problem.sinput}</pre>
+                  <p>Output:</p>
+                  <pre>{problem.soutput}</pre>
+                </li>
               </ul>
-            )
-          )}
-          <h2>Solve</h2>
-          <TextBox socketRef={socketRef} currentProbId={id} />
+            ) : (
+              problem.sample_input && problem.sample_outputs && (
+                <ul>
+                  {problem.sample_input.map((input, idx) => (
+                    <li key={idx}>
+                      <p>Input:</p>
+                      <pre>{input}</pre>
+                      <p>Output:</p>
+                      <pre>{problem.sample_outputs[idx]}</pre>
+                    </li>
+                  ))}
+                </ul>
+              )
+            )}
+          </div>
+          <div className="editor-view">
+            <TextBox socketRef={socketRef} currentProbId={id} />
+          </div>
+          <div className="chat-view">
+            <ChatBox socketRef={socketRef} username={username || 'Anon'} />
+          </div>
         </div>
       ) : (
         <p>Loading...</p>

--- a/codespace/frontend/src/styles/ProblemDetailPage.css
+++ b/codespace/frontend/src/styles/ProblemDetailPage.css
@@ -1,0 +1,14 @@
+.problem-detail-container {
+  display: flex;
+  gap: 10px;
+  height: 90vh;
+}
+
+.problem-view,
+.editor-view,
+.chat-view {
+  flex: 1;
+  border: 1px solid #ccc;
+  padding: 10px;
+  overflow-y: auto;
+}


### PR DESCRIPTION
## Summary
- Rework `ProblemDetailPage` to render problem view, code editor, and general chat in dedicated flexbox areas
- Establish socket connection for collaborative editor and chat
- Add CSS layout for the three-column problem page

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68a4bcd590ac832893f4b09adad9a14d