### PR TITLE
Refactor room page layout with problem view toggle, editor, and chat

### DIFF
--- a/codespace/frontend/src/components/Room.js
+++ b/codespace/frontend/src/components/Room.js
@@ -3,7 +3,6 @@ import '../styles/App.css'
 import React, { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import MiniDrawer from './SideDrawer';
-import Split from 'react-split';
 import MainLHS from './LHS/MainLHS';
 import ChatBox from './ChatBox';
 import io from 'socket.io-client';
@@ -55,6 +54,7 @@ export default function Room() {
     const [members, setMembers] = useState([]);
     const [isMicOn, setIsMicOn] = useState(false);
     const [currentProbId,setCurrentProb] = useState(null);
+    const [showProblem, setShowProblem] = useState(false);
     const userVideo = useRef();
     const socketRef = useRef();
     const peersRef = useRef([]);
@@ -97,6 +97,10 @@ export default function Room() {
         socketRef.current.disconnect();
       }
       navigate('/rooms');
+    };
+
+    const toggleProblemView = () => {
+      setShowProblem(prev => !prev);
     };
 
     useEffect(() => {
@@ -196,45 +200,32 @@ export default function Room() {
         <div className="editor-background">
         <button className="leave-room-button" onClick={leaveRoom}>Leave Room</button>
         <MiniDrawer toggleMic={toggleMic} roomid={roomid} members={members} isMicOn={isMicOn}>
-        <div className='main'>
-            <Split
-              direction='vertical'
-              sizes={[80, 20]}
-              minSize={100}
-              className='vertical-split'
-            >
-              <div className='top-pane'>
-                <Split
-                  sizes={[40, 60]}
-                  minSize={200}
-                  maxSize={1000}
-                  direction="horizontal"
-                  gutterSize={10}
-                  gutterAlign="center"
-                  className="split"
-                  gutter={(index, direction) => {
-                      const gutter = document.createElement('div');
-                      gutter.className = `gutter gutter-${direction}`;
-                      return gutter;
-                  }}
-                >
-                  <div className="LHS-container">
-                    <MainLHS socketRef={socketRef} currentProbId={currentProbId} setCurrentProb={setCurrentProb} />
-                  </div>
-                  <div className="RHS-container">
-                    <TextBox socketRef={socketRef} currentProbId={currentProbId} />
-                  </div>
-                </Split>
-                <Container>
-                  <StyledVideo muted ref={userVideo} autoPlay playsInline />
-                  {peers.map((peer, index) => (
-                    <Video key={index} peer={peer} />
-                  ))}
-                </Container>
-              </div>
-              <ChatBox socketRef={socketRef} username={username} />
-            </Split>
+        <div className='room-main'>
+          <div className='problem-view'>
+            <button className='view-problem-button' onClick={toggleProblemView}>
+              {showProblem ? 'Hide Problem' : 'View Problem'}
+            </button>
+            {showProblem && (
+              <MainLHS
+                socketRef={socketRef}
+                currentProbId={currentProbId}
+                setCurrentProb={setCurrentProb}
+              />
+            )}
+          </div>
+          <div className='editor-container'>
+            <TextBox socketRef={socketRef} currentProbId={currentProbId} />
+          </div>
+          <div className='chat-container'>
+            <ChatBox socketRef={socketRef} username={username} />
+          </div>
         </div>
+        <Container style={{ display: 'none' }}>
+          <StyledVideo muted ref={userVideo} autoPlay playsInline />
+          {peers.map((peer, index) => (
+            <Video key={index} peer={peer} />
+          ))}
+        </Container>
         </MiniDrawer>
         </div>
     );

--- a/codespace/frontend/src/styles/RoomPage.css
+++ b/codespace/frontend/src/styles/RoomPage.css
@@ -9,37 +9,36 @@
   transition: background 0.5s ease;
 }
 
-.editor-background .main {
+.room-main {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
   overflow: auto;
 }
 
-.split {
-  height: 100%;
-}
-
-.vertical-split {
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-}
-
-.top-pane {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-}
-
-.top-pane .split {
-  flex: 1;
-}
-
-.LHS-container,
-.RHS-container {
+.problem-view,
+.editor-container,
+.chat-container {
   background: #ffffff;
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  overflow: hidden;
+  padding: 1rem;
+}
+
+.view-problem-button {
+  margin-bottom: 1rem;
+  padding: 0.5rem 1rem;
+  background: #1976d2;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+.view-problem-button:hover {
+  background: #115293;
 }
 
 .member-card {


### PR DESCRIPTION
## Summary
- Simplify room layout to show problem, editor, and general chat in central section
- Add "View Problem" toggle to display or hide problem statement
- Update styles for new three-pane layout while keeping sidebar intact

## Testing
- `cd codespace/frontend && npm test -- --watchAll=false`
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68a4bf042db48328aeeab3f25d114f45