### PR TITLE
Add floating chat widget and default home route

### DIFF
--- a/codespace/frontend/src/components/ChatWidget.js
+++ b/codespace/frontend/src/components/ChatWidget.js
@@ -1,0 +1,22 @@
+import React, { useState } from 'react';
+import ChatBox from './ChatBox';
+import '../styles/ChatWidget.css';
+
+export default function ChatWidget({ socketRef, username }) {
+  const [open, setOpen] = useState(false);
+
+  const toggleChat = () => setOpen((prev) => !prev);
+
+  return (
+    <div className="chat-widget">
+      {open && (
+        <div className="chat-popup">
+          <ChatBox socketRef={socketRef} username={username} />
+        </div>
+      )}
+      <button className="chat-toggle" onClick={toggleChat} aria-label="Toggle chat">
+        {open ? '\u2715' : '\ud83d\udd8a\ufe0f'}
+      </button>
+    </div>
+  );
+}

--- a/codespace/frontend/src/index.js
+++ b/codespace/frontend/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import './styles/index.css';
 import App from './App';
 import ProblemDetailPage from './pages/ProblemDetailPage';
@@ -16,7 +16,8 @@ root.render(
   <BrowserRouter>
     <Routes>
       <Route path="/problems/:id" element={<ProblemDetailPage />} />
-      <Route path="/*" element={<App />} />
+      <Route path="/" element={<App />} />
+      <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   </BrowserRouter>
 );

--- a/codespace/frontend/src/pages/ProblemDetailPage.js
+++ b/codespace/frontend/src/pages/ProblemDetailPage.js
@@ -4,7 +4,7 @@ import axios from 'axios';
 import io from 'socket.io-client';
 import NavBar from '../components/NavBar';
 import TextBox from '../components/TextBox';
-import ChatBox from '../components/ChatBox';
+import ChatWidget from '../components/ChatWidget';
 import BACKEND_URL from '../config';
 import '../styles/ProblemDetailPage.css';
 
@@ -48,6 +48,7 @@ function ProblemDetailPage() {
     <div>
       <NavBar />
       {problem ? (
+        <>
         <div className="problem-detail-container">
           <div className="problem-view">
             <h1>{problem.problem_name || problem.title}</h1>
@@ -80,10 +81,9 @@ function ProblemDetailPage() {
           <div className="editor-view">
             <TextBox socketRef={socketRef} currentProbId={id} />
           </div>
-          <div className="chat-view">
-            <ChatBox socketRef={socketRef} username={username || 'Anon'} />
-          </div>
         </div>
+        <ChatWidget socketRef={socketRef} username={username || 'Anon'} />
+        </>
       ) : (
         <p>Loading...</p>
       )}

--- a/codespace/frontend/src/styles/ChatWidget.css
+++ b/codespace/frontend/src/styles/ChatWidget.css
@@ -1,0 +1,30 @@
+.chat-widget {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 1000;
+}
+
+.chat-toggle {
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  border: none;
+  background: #1976d2;
+  color: #fff;
+  font-size: 24px;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+.chat-popup {
+  position: absolute;
+  bottom: 60px;
+  right: 0;
+  width: 300px;
+  height: 400px;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  border-radius: 8px;
+  overflow: hidden;
+}

--- a/codespace/frontend/src/styles/ProblemDetailPage.css
+++ b/codespace/frontend/src/styles/ProblemDetailPage.css
@@ -1,12 +1,12 @@
 .problem-detail-container {
   display: flex;
+  flex-direction: column;
   gap: 10px;
   height: 90vh;
 }
 
 .problem-view,
-.editor-view,
-.chat-view {
+.editor-view {
   flex: 1;
   border: 1px solid #ccc;
   padding: 10px;


### PR DESCRIPTION
## Summary
- Ensure the application loads the main page by default with a fallback redirect
- Restructure problem detail page to stack problem and editor vertically
- Introduce a fixed chat widget that pops up in the bottom-right corner

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68a4c25a592c8328bf477e3b5feb9172