### PR TITLE
Fix frontend routing to enable navigation

### DIFF
--- a/codespace/frontend/src/App.js
+++ b/codespace/frontend/src/App.js
@@ -2,7 +2,7 @@ import './styles/App.css';
 import HomePage from './pages/HomePage';
 import LoginPage from './pages/LoginPage';
 import SignupPage from './pages/SignupPage';
-import { Route, Routes } from 'react-router-dom';
+import { Route, Routes, Navigate } from 'react-router-dom';
 import Room from './components/Room';
 import ContestPage from './pages/ContestPage';
 import RoomsPage from './pages/RoomsPage';
@@ -27,6 +27,7 @@ function App(){
         <Route path="/contact" element={<ContactPage />} />
         <Route path="/profile" element={<ProfilePage />} />
         <Route path="/room" element={<Room />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
   );
 }

--- a/codespace/frontend/src/index.js
+++ b/codespace/frontend/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import './styles/index.css';
 import App from './App';
 import ProblemDetailPage from './pages/ProblemDetailPage';
@@ -16,8 +16,7 @@ root.render(
   <BrowserRouter>
     <Routes>
       <Route path="/problems/:id" element={<ProblemDetailPage />} />
-      <Route path="/" element={<App />} />
-      <Route path="*" element={<Navigate to="/" replace />} />
+      <Route path="/*" element={<App />} />
     </Routes>
   </BrowserRouter>
 );


### PR DESCRIPTION
## Summary
- Allow nested routes by mounting `<App />` at `/*` instead of `/`
- Add wildcard redirect in `App` to handle unknown pages

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a4c4caa24883289310b5036a5c49c4