### PR TITLE
Improve chat widget and editor visibility

### DIFF
--- a/codespace/frontend/src/styles/ChatWidget.css
+++ b/codespace/frontend/src/styles/ChatWidget.css
@@ -21,7 +21,7 @@
   position: absolute;
   bottom: 60px;
   right: 0;
-  width: 300px;
+  width: 400px;
   height: 400px;
   background: #fff;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);

--- a/codespace/frontend/src/styles/ProblemDetailPage.css
+++ b/codespace/frontend/src/styles/ProblemDetailPage.css
@@ -3,6 +3,7 @@
   flex-direction: column;
   gap: 10px;
   height: 90vh;
+  overflow-y: auto;
 }
 
 .problem-view,


### PR DESCRIPTION
## Summary
- Expand chat widget popup to 400x400px for better readability
- Allow problem detail container to scroll so the editor stays visible

## Testing
- `npm test --silent -- --watchAll=false`
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a4cca3164c8328863c575c78f8288e