### PR TITLE
Fix editor overflow hiding controls and chat

### DIFF
--- a/codespace/frontend/src/components/TextBox.js
+++ b/codespace/frontend/src/components/TextBox.js
@@ -108,7 +108,13 @@ export default function TextBox({socketRef,currentProbId}) {
     return (
     <div className="RHS">
         <div className="code-area">
-            <CodeMirror value={textvalue} width='170vh' height="86vh" onChange={Handlechange} extensions={[cpp()]} />
+            <CodeMirror
+                value={textvalue}
+                height="60vh"
+                width="100%"
+                onChange={Handlechange}
+                extensions={[cpp()]}
+            />
         </div>
         <div className="input-output">
             <div className="input-area">

--- a/codespace/frontend/src/styles/RoomPage.css
+++ b/codespace/frontend/src/styles/RoomPage.css
@@ -1,11 +1,10 @@
 .editor-background {
   position: relative;
   min-height: 100vh;
-  height: 100vh;
   background: linear-gradient(135deg, #e3f2fd, #ffffff);
   display: flex;
   flex-direction: column;
-  overflow: visible;
+  overflow-y: auto;
   transition: background 0.5s ease;
 }
 
@@ -14,7 +13,7 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  overflow: auto;
+  overflow: visible;
 }
 
 .problem-view,


### PR DESCRIPTION
## Summary
- Allow editor page to scroll so sections below are visible
- Reduce code editor size and make it responsive

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a4d0349ccc8328a9392b554034222f