### PR TITLE
Refactor room layout with persistent chat sidebar

### DIFF
--- a/codespace/frontend/src/components/MembersList.js
+++ b/codespace/frontend/src/components/MembersList.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import MicOffIcon from '@mui/icons-material/MicOff';
+import MicIcon from '@mui/icons-material/Mic';
+
+const emojis = ['🧑', '👨', '🧔', '👩', '👩‍💻', '👨‍💻'];
+
+export default function MembersList({ members = [] }) {
+  return (
+    <div>
+      {members.map((member, index) => {
+        const emoji = emojis[index % emojis.length];
+        return (
+          <div key={index} className="member-card">
+            <span className="emoji">{emoji}</span>
+            <span className="id">{member.username}</span>
+            {member.micOn ? (
+              <MicIcon fontSize="small" style={{ marginLeft: 'auto' }} />
+            ) : (
+              <MicOffIcon fontSize="small" style={{ marginLeft: 'auto' }} />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/codespace/frontend/src/components/Room.js
+++ b/codespace/frontend/src/components/Room.js
@@ -2,9 +2,12 @@ import TextBox from './TextBox';
 import '../styles/App.css'
 import React, { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import MiniDrawer from './SideDrawer';
 import MainLHS from './LHS/MainLHS';
 import ChatBox from './ChatBox';
+import MembersList from './MembersList';
+import IconButton from '@mui/material/IconButton';
+import HeadsetMicIcon from '@mui/icons-material/HeadsetMic';
+import MicOffIcon from '@mui/icons-material/MicOff';
 import io from 'socket.io-client';
 import SimplePeer from 'simple-peer';
 import BACKEND_URL from '../config';
@@ -199,26 +202,37 @@ export default function Room() {
       return (
         <div className="editor-background">
         <button className="leave-room-button" onClick={leaveRoom}>Leave Room</button>
-        <MiniDrawer toggleMic={toggleMic} roomid={roomid} members={members} isMicOn={isMicOn}>
-        <div className='room-main'>
-          <div className='problem-view'>
-            <button className='view-problem-button' onClick={toggleProblemView}>
-              {showProblem ? 'Hide Problem' : 'View Problem'}
-            </button>
-            {showProblem && (
-              <MainLHS
-                socketRef={socketRef}
-                currentProbId={currentProbId}
-                setCurrentProb={setCurrentProb}
-              />
-            )}
+        <div className='room-wrapper'>
+          <div className='room-main'>
+            <div className='problem-view'>
+              <button className='view-problem-button' onClick={toggleProblemView}>
+                {showProblem ? 'Hide Problem' : 'View Problem'}
+              </button>
+              {showProblem && (
+                <MainLHS
+                  socketRef={socketRef}
+                  currentProbId={currentProbId}
+                  setCurrentProb={setCurrentProb}
+                />
+              )}
+            </div>
+            <div className='editor-container'>
+              <TextBox socketRef={socketRef} currentProbId={currentProbId} />
+            </div>
           </div>
-          <div className='editor-container'>
-            <TextBox socketRef={socketRef} currentProbId={currentProbId} />
-          </div>
-          <div className='chat-container'>
-            <ChatBox socketRef={socketRef} username={username} />
-          </div>
+          <aside className='right-sidebar'>
+            <div className='members-section'>
+              <IconButton variant="contained" color="primary" onClick={toggleMic}>
+                {isMicOn ? <HeadsetMicIcon /> : <MicOffIcon />}
+              </IconButton>
+              <div className='members-list'>
+                <MembersList members={members} />
+              </div>
+            </div>
+            <div className='chat-section'>
+              <ChatBox socketRef={socketRef} username={username} />
+            </div>
+          </aside>
         </div>
         <Container style={{ display: 'none' }}>
           <StyledVideo muted ref={userVideo} autoPlay playsInline />
@@ -226,7 +240,6 @@ export default function Room() {
             <Video key={index} peer={peer} />
           ))}
         </Container>
-        </MiniDrawer>
         </div>
     );
 };

--- a/codespace/frontend/src/styles/ChatBox.css
+++ b/codespace/frontend/src/styles/ChatBox.css
@@ -7,6 +7,7 @@
   border-top: 2px solid #ddd;
   position: relative;
   z-index: 10;
+  flex: 1;
 }
 
 .chat-messages {

--- a/codespace/frontend/src/styles/RoomPage.css
+++ b/codespace/frontend/src/styles/RoomPage.css
@@ -8,6 +8,11 @@
   transition: background 0.5s ease;
 }
 
+.room-wrapper {
+  flex: 1;
+  display: flex;
+}
+
 .room-main {
   flex: 1;
   display: flex;
@@ -17,12 +22,42 @@
 }
 
 .problem-view,
-.editor-container,
-.chat-container {
+.editor-container {
   background: #ffffff;
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   padding: 1rem;
+}
+
+.right-sidebar {
+  width: 300px;
+  display: flex;
+  flex-direction: column;
+  margin-left: 1rem;
+}
+
+.members-section {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.members-list {
+  max-height: 8rem;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+
+.chat-section {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  margin-top: 1rem;
+}
+
+.chat-section .chat-container {
+  flex: 1;
 }
 
 .view-problem-button {


### PR DESCRIPTION
## Summary
- Add MembersList component and relocate ChatBox into fixed right sidebar
- Style room page so member list and chat stack vertically and fill sidebar
- Ensure ChatBox spans available height and remains visible alongside main editor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4f9346c5c8328b5318fafccfc6019