### PR TITLE
Reposition room sidebar and streamline chat

### DIFF
--- a/codespace/frontend/src/components/ChatBox.js
+++ b/codespace/frontend/src/components/ChatBox.js
@@ -1,9 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import '../styles/ChatBox.css';
 
 export default function ChatBox({ socketRef, username }) {
   const [message, setMessage] = useState('');
   const [messages, setMessages] = useState([]);
+  const messagesEndRef = useRef(null);
 
   useEffect(() => {
     if (socketRef.current) {
@@ -14,6 +15,10 @@ export default function ChatBox({ socketRef, username }) {
       return () => socketRef.current.off('receive message', handler);
     }
   }, [socketRef]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
 
   const sendMessage = (e) => {
     e.preventDefault();
@@ -35,6 +40,7 @@ export default function ChatBox({ socketRef, username }) {
             <span className="chat-text">{m.msg}</span>
           </div>
         ))}
+        <div ref={messagesEndRef} />
       </div>
       <form className="chat-input" onSubmit={sendMessage}>
         <input

--- a/codespace/frontend/src/components/Room.js
+++ b/codespace/frontend/src/components/Room.js
@@ -203,6 +203,19 @@ export default function Room() {
         <div className="editor-background">
         <button className="leave-room-button" onClick={leaveRoom}>Leave Room</button>
         <div className='room-wrapper'>
+          <aside className='left-sidebar'>
+            <div className='members-section'>
+              <IconButton variant="contained" color="primary" onClick={toggleMic}>
+                {isMicOn ? <HeadsetMicIcon /> : <MicOffIcon />}
+              </IconButton>
+              <div className='members-list'>
+                <MembersList members={members} />
+              </div>
+            </div>
+            <div className='chat-section'>
+              <ChatBox socketRef={socketRef} username={username} />
+            </div>
+          </aside>
           <div className='room-main'>
             <div className='problem-view'>
               <button className='view-problem-button' onClick={toggleProblemView}>
@@ -220,19 +233,6 @@ export default function Room() {
               <TextBox socketRef={socketRef} currentProbId={currentProbId} />
             </div>
           </div>
-          <aside className='right-sidebar'>
-            <div className='members-section'>
-              <IconButton variant="contained" color="primary" onClick={toggleMic}>
-                {isMicOn ? <HeadsetMicIcon /> : <MicOffIcon />}
-              </IconButton>
-              <div className='members-list'>
-                <MembersList members={members} />
-              </div>
-            </div>
-            <div className='chat-section'>
-              <ChatBox socketRef={socketRef} username={username} />
-            </div>
-          </aside>
         </div>
         <Container style={{ display: 'none' }}>
           <StyledVideo muted ref={userVideo} autoPlay playsInline />

--- a/codespace/frontend/src/pages/ProblemDetailPage.js
+++ b/codespace/frontend/src/pages/ProblemDetailPage.js
@@ -4,7 +4,6 @@ import axios from 'axios';
 import io from 'socket.io-client';
 import NavBar from '../components/NavBar';
 import TextBox from '../components/TextBox';
-import ChatWidget from '../components/ChatWidget';
 import BACKEND_URL from '../config';
 import '../styles/ProblemDetailPage.css';
 
@@ -12,7 +11,6 @@ function ProblemDetailPage() {
   const { id } = useParams();
   const [problem, setProblem] = useState(null);
   const socketRef = useRef(null);
-  const username = localStorage.getItem('username');
 
   useEffect(() => {
     async function fetchProblem() {
@@ -82,7 +80,6 @@ function ProblemDetailPage() {
             <TextBox socketRef={socketRef} currentProbId={id} />
           </div>
         </div>
-        <ChatWidget socketRef={socketRef} username={username || 'Anon'} />
         </>
       ) : (
         <p>Loading...</p>

--- a/codespace/frontend/src/styles/RoomPage.css
+++ b/codespace/frontend/src/styles/RoomPage.css
@@ -29,11 +29,11 @@
   padding: 1rem;
 }
 
-.right-sidebar {
+.left-sidebar {
   width: 300px;
   display: flex;
   flex-direction: column;
-  margin-left: 1rem;
+  margin-right: 1rem;
 }
 
 .members-section {


### PR DESCRIPTION
## Summary
- Move room sidebar to the left and keep members list and chat there
- Remove problem-page chat widget so chat only appears inside rooms
- Auto-scroll chat messages for real-time conversation

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a4fd8fb8bc8328bbf46a98cf135abf