### PR TITLE
Ensure scraping dependencies installed

### DIFF
--- a/codespace/setup.sh
+++ b/codespace/setup.sh
@@ -1,2 +1,11 @@
+#!/bin/sh
+set -e
+
 docker pull nubskr/compiler:1
-docker network create --internal mynetwork
+# Create internal network if it doesn't already exist
+if ! docker network ls --format '{{.Name}}' | grep -q '^mynetwork$'; then
+  docker network create --internal mynetwork
+fi
+
+# Install Python dependencies required for scraping Codeforces problems
+pip3 install -r "$(dirname "$0")/server/requirements.txt"


### PR DESCRIPTION
## Summary
- Improve setup script to install Python dependencies so Codeforces scraper runs
- Safely create Docker network if missing

## Testing
- `bash -n codespace/setup.sh`
- `pip3 install -r codespace/server/requirements.txt`
- `python3 codespace/server/routes/scraper.py https://codeforces.com/problemset/problem/2131/D`


------
https://chatgpt.com/codex/tasks/task_e_68a59010f1188328b1ccbb73c4cc2e4d