### PR TITLE
fix: install python deps in virtualenv for server

### DIFF
--- a/codespace/server/Dockerfile
+++ b/codespace/server/Dockerfile
@@ -3,7 +3,9 @@ RUN apk add --no-cache docker-cli python3 py3-pip
 WORKDIR /app
 COPY package*.json requirements.txt ./
 RUN npm install --production
-RUN pip3 install --no-cache-dir -r requirements.txt
+RUN python3 -m venv /opt/venv \
+    && /opt/venv/bin/pip install --no-cache-dir -r requirements.txt
+ENV PATH="/opt/venv/bin:$PATH"
 COPY . .
 EXPOSE 6909
 CMD ["npm","start"]


### PR DESCRIPTION
## Summary
- create virtualenv in server Dockerfile to install Python packages without hitting PEP 668

## Testing
- `docker compose build server` *(fails: command not found)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5c1f20a048328a13f4be6212e03a4