### PR TITLE
feat: add referer header for codeforces scraper

### DIFF
--- a/codespace/server/routes/scraper.py
+++ b/codespace/server/routes/scraper.py
@@ -9,8 +9,11 @@ import sys
 url = sys.argv[1]
 
 try:
-    headers = {"User-Agent": "Mozilla/5.0"}
-    response = requests.get(url, headers=headers)
+    headers = {
+        "User-Agent": "Mozilla/5.0",
+        "Referer": "https://codeforces.com/"
+    }
+    response = requests.get(url, headers=headers, timeout=10)
     response.raise_for_status()
 except Exception as e:
     print(str(e), file=sys.stderr)


### PR DESCRIPTION
## Summary
- include `Referer` header and request timeout in Codeforces problem scraper

## Testing
- `python3 -m py_compile codespace/server/routes/scraper.py`
- `python3 codespace/server/routes/scraper.py https://codeforces.com/problemset/problem/1/A`

------
https://chatgpt.com/codex/tasks/task_e_68a5c4e0939883289f53c0a49f23000e