### PR TITLE
Enhance editor and chat UI

### DIFF
--- a/codespace/frontend/src/components/ChatBox.js
+++ b/codespace/frontend/src/components/ChatBox.js
@@ -27,6 +27,7 @@ export default function ChatBox({ socketRef, username }) {
     if (socketRef.current) {
       socketRef.current.emit('send-message', { msg: trimmed });
     }
+    setMessages((prev) => [...prev, { username, msg: trimmed }]);
     setMessage('');
   };
 

--- a/codespace/frontend/src/components/TextBox.js
+++ b/codespace/frontend/src/components/TextBox.js
@@ -119,17 +119,17 @@ export default function TextBox({socketRef,currentProbId}) {
         <div className="input-output">
             <div className="input-area">
                 <textarea
-                    style={{height: '5vh',resize: "none" }}
+                    style={{ height: '5vh', resize: 'none' }}
                     id="input"
                     value={inputvalue}
                     onChange={Handlechangeinput}
                     placeholder="Enter input here"
                 ></textarea>
             </div>
-            <div className="output-area" style={{ padding: '1px', width: '100%', height: '6vh', border: '2px solid black' , color: color}}>
-  Output: {outputvalue}
-</div>
-{/* <div> Output Value: {outputvalue}</div> */}
+            <div className="output-area" style={{ color }}>
+                Output: {outputvalue}
+            </div>
+            {/* <div> Output Value: {outputvalue}</div> */}
         </div>
         <div>
             <button onClick={Handlecompile}>Compile</button>

--- a/codespace/frontend/src/styles/App.css
+++ b/codespace/frontend/src/styles/App.css
@@ -42,11 +42,45 @@ input {
   flex-direction: column;
 }
 
+.code-area {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
 .input-output {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  flex: 1; /* The input/output area takes up the remaining space */
+  flex-direction: column;
+  gap: 0.75rem;
+  flex: 1;
+  margin-top: 1rem;
+}
+
+@media (min-width: 768px) {
+  .input-output {
+    flex-direction: row;
+  }
+}
+
+.input-area,
+.output-area {
+  flex: 1;
+}
+
+.input-area textarea {
+  width: 100%;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background: #fafafa;
+}
+
+.output-area {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  background: #ffffff;
+  min-height: 6vh;
 }
 
 button {

--- a/codespace/frontend/src/styles/RoomPage.css
+++ b/codespace/frontend/src/styles/RoomPage.css
@@ -29,6 +29,13 @@
   padding: 1rem;
 }
 
+.editor-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 60vh;
+}
+
 .left-sidebar {
   width: 300px;
   display: flex;


### PR DESCRIPTION
## Summary
- Revamp editor container with a flexible, spacious layout
- Restyle input/output areas for clearer separation and responsiveness
- Ensure room chat shows sent messages immediately for live feedback

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a77faceb548328b0352bc914467d0f