### PR TITLE
Persist room chat messages with history limit

### DIFF
--- a/codespace/server/app.js
+++ b/codespace/server/app.js
@@ -54,6 +54,7 @@ const {
   getUsersInRoom,
   updateMicStatus,
   addMessage,
+  getMessages,
 } = require('./utils/roomStore');
 const username_to_socket = {};
 const pairSet = new Map();
@@ -107,6 +108,15 @@ io.on('connection', (socket) => {
             username: socket.username,
             msg: payload.msg
         });
+    })
+
+    socket.on('get-messages', async () => {
+        const history = await getMessages(socket.roomid);
+        socket.emit('room-messages', history.map(m => ({
+            userid: m.userid,
+            username: m.username,
+            msg: m.message
+        })));
     })
 
     socket.on('sending offer', (payload) => {

--- a/codespace/server/utils/roomStore.js
+++ b/codespace/server/utils/roomStore.js
@@ -36,8 +36,11 @@ async function addMessage(roomid, userid, username, msg) {
   await message.save();
 }
 
-async function getMessages(roomid) {
-  return await Message.find({ roomid }).sort({ createdAt: 1 });
+async function getMessages(roomid, limit = 50) {
+  const messages = await Message.find({ roomid })
+    .sort({ createdAt: -1 })
+    .limit(limit);
+  return messages.reverse();
 }
 
 module.exports = {


### PR DESCRIPTION
## Summary
- add socket endpoint to fetch stored messages per room
- persist room messages and send limited history to clients
- cap chat box memory to last 50 messages and load history on mount

## Testing
- `npm test` (server) *(fails: Missing script: "test")*
- `npm test -- --watchAll=false` (frontend) *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a784f815c083289ea94da273ab44df