### PR TITLE
Persist room chat history and tidy up on room removal

### DIFF
--- a/codespace/frontend/src/components/ChatBox.js
+++ b/codespace/frontend/src/components/ChatBox.js
@@ -22,7 +22,6 @@ export default function ChatBox({ socketRef, username }) {
       const handler = (payload) => {
         setMessages(payload.map(m => ({ username: m.username, msg: m.msg })));
       };
-      socketRef.current.emit('get-messages');
       socketRef.current.on('room-messages', handler);
       return () => socketRef.current.off('room-messages', handler);
     }

--- a/codespace/server/app.js
+++ b/codespace/server/app.js
@@ -91,6 +91,13 @@ io.on('connection', (socket) => {
         const usersInRoom = await getUsersInRoom(payload.roomid);
         io.to(socket.roomid).emit('all users',{users: usersInRoom.map(u => u.userid)});
         io.to(socket.roomid).emit('users-in-room', { users: usersInRoom.map(u => ({ userid: u.userid, username: u.username, micOn: u.micOn })) });
+
+        const history = await getMessages(payload.roomid);
+        socket.emit('room-messages', history.map(m => ({
+            userid: m.userid,
+            username: m.username,
+            msg: m.message
+        })));
     })
     
     socket.on('update-code', (payload) => {

--- a/codespace/server/routes/rooms.js
+++ b/codespace/server/routes/rooms.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const mongoose = require('mongoose');
 const Room = require('../model/roomModel');
-const { getUsersInRoom, getMessages } = require('../utils/roomStore');
+const { getUsersInRoom, getMessages, deleteMessages } = require('../utils/roomStore');
 
 const router = express.Router();
 const url = process.env.MONGODB_URI || 'mongodb://localhost:27017/graduation_project';
@@ -68,6 +68,16 @@ router.post('/join', async (req, res) => {
     try {
       const messages = await getMessages(req.params.id);
       res.json(messages);
+    } catch (err) {
+      res.status(500).json({ message: 'Server error' });
+    }
+  });
+
+  router.delete('/:id', async (req, res) => {
+    try {
+      await Room.deleteOne({ roomid: req.params.id });
+      await deleteMessages(req.params.id);
+      res.json({ message: 'Room deleted' });
     } catch (err) {
       res.status(500).json({ message: 'Server error' });
     }

--- a/codespace/server/utils/roomStore.js
+++ b/codespace/server/utils/roomStore.js
@@ -43,6 +43,10 @@ async function getMessages(roomid, limit = 50) {
   return messages.reverse();
 }
 
+async function deleteMessages(roomid) {
+  await Message.deleteMany({ roomid });
+}
+
 module.exports = {
   addUserToRoom,
   removeUserFromRoom,
@@ -51,4 +55,5 @@ module.exports = {
   updateMicStatus,
   addMessage,
   getMessages,
+  deleteMessages,
 };


### PR DESCRIPTION
## Summary
- send existing room messages to clients when they join so chats survive refreshes
- clean up room chat records when a room is deleted
- rely on `room-messages` in chat widget to populate the last 50 messages

## Testing
- `npm test` *(server: Missing script "test")*
- `npm test -- --watchAll=false` *(frontend: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a787b954308328bd72f7c304aea870