### PR TITLE
Fix chat socket initialization for live message updates

### DIFF
--- a/codespace/frontend/src/components/Room.js
+++ b/codespace/frontend/src/components/Room.js
@@ -76,6 +76,7 @@ export default function Room() {
     const [fetchOpen, setFetchOpen] = useState(false);
     const userVideo = useRef();
     const socketRef = useRef();
+    const [socket, setSocket] = useState(null);
     const peersRef = useRef([]);
     const streamRef = useRef();
     const navigate = useNavigate();
@@ -127,6 +128,7 @@ export default function Room() {
 
     useEffect(() => {
       socketRef.current = io(BACKEND_URL, { transports: ['websocket'] });
+      setSocket(socketRef.current);
 
       // previous implementation relied on an 'all users' broadcast which
       // could fire before a microphone stream was available, leaving new
@@ -232,7 +234,7 @@ export default function Room() {
               </div>
             </div>
             <div className='chat-section'>
-              <ChatBox socketRef={socketRef} username={username} />
+              <ChatBox socket={socket} username={username} />
             </div>
           </aside>
           <div className='room-main'>


### PR DESCRIPTION
## Summary
- ensure chat component connects after socket setup for live updates
- request stored room messages and keep only latest 50 messages
- pass active socket to chat box for scrollable message queue

## Testing
- `npm test --silent -- --watchAll=false` *(frontend: no tests found)*
- `npm test` *(server: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a78ad01f448328be79141f61d8b966