### PR TITLE
Improve chat layout and styling

### DIFF
--- a/codespace/frontend/src/styles/ChatBox.css
+++ b/codespace/frontend/src/styles/ChatBox.css
@@ -1,35 +1,49 @@
+/* Main chat container fills all available space within its parent */
 .chat-container {
   width: 100%;
   height: 100%;
   display: flex;
   flex-direction: column;
   background: #f5f5f5;
-  border-top: 2px solid #ddd;
+  border: 1px solid #ddd;
+  border-radius: 8px;
   position: relative;
   z-index: 10;
   flex: 1;
+  overflow: hidden;
 }
 
+/* Scrollable message list */
 .chat-messages {
   flex: 1;
-  padding: 0.5rem;
+  padding: 0.75rem;
   overflow-y: auto;
+  background: #fafafa;
 }
 
+/* Individual message bubble */
 .chat-message {
   display: flex;
   align-items: center;
-  margin-bottom: 0.25rem;
-  padding: 0.25rem 0.5rem;
-  background: #ffffff;
-  border-radius: 6px;
+  margin-bottom: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  background: #e0e0e0;
+  border-radius: 12px;
   word-break: break-word;
+  max-width: 80%;
 }
 
+/* Messages from the current user appear on the right */
 .chat-message.self {
-  background: #d1e7dd;
+  background: #1976d2;
+  color: #fff;
   margin-left: auto;
   justify-content: flex-end;
+}
+
+.chat-message.self .chat-user,
+.chat-message.self .chat-text {
+  color: #fff;
 }
 
 .chat-emoji {
@@ -46,26 +60,35 @@
   color: #333;
 }
 
+/* Input section with message box and send button */
 .chat-input {
   display: flex;
+  align-items: center;
   border-top: 1px solid #ccc;
   background: #fff;
+  padding: 0.5rem;
+  gap: 0.5rem;
 }
 
 .chat-input input {
   flex: 1;
-  padding: 0.5rem;
-  border: none;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
   outline: none;
   background: #fff;
 }
 
 .chat-input button {
-  padding: 0 1rem;
+  padding: 0.5rem 1rem;
   border: none;
+  border-radius: 4px;
   background: #1976d2;
   color: #fff;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .chat-input button:hover {

--- a/codespace/frontend/src/styles/RoomPage.css
+++ b/codespace/frontend/src/styles/RoomPage.css
@@ -41,6 +41,7 @@
   display: flex;
   flex-direction: column;
   margin-right: 1rem;
+  height: 100%;
 }
 
 .members-section {
@@ -61,8 +62,6 @@
   flex-direction: column;
   min-height: 0;
   margin-top: 1rem;
-  max-height: 40vh;
-  overflow: hidden;
 }
 
 .chat-section .chat-container {


### PR DESCRIPTION
## Summary
- Expand chat sidebar to use full height of its container
- Modernize chat bubbles and input area styling

## Testing
- `cd codespace/frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a793499d6c832893d7e0b98538bf36