### PR TITLE
Fix contact nav layout and enhance profile menu

### DIFF
--- a/codespace/frontend/src/components/NavBar.js
+++ b/codespace/frontend/src/components/NavBar.js
@@ -1,12 +1,18 @@
 import React, { useState, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import AccountCircle from '@mui/icons-material/AccountCircle';
+import Logout from '@mui/icons-material/Logout';
 import '../styles/NavBar.css';
 import logo from '../assets/images/logo.svg';
 import userIcon from '../assets/images/user.svg';
 
 function NavBar() {
   const [loggedIn, setLoggedIn] = useState(false);
-  const [open, setOpen] = useState(false);
+  const [anchorEl, setAnchorEl] = useState(null);
+  const open = Boolean(anchorEl);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -14,10 +20,18 @@ function NavBar() {
     setLoggedIn(!!token);
   }, []);
 
+  const handleMenu = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
   const handleLogout = () => {
     localStorage.removeItem('token');
     setLoggedIn(false);
-    setOpen(false);
+    handleClose();
     navigate('/login');
   };
 
@@ -39,21 +53,29 @@ function NavBar() {
         {!loggedIn && <li><Link to="/login">Login</Link></li>}
         {loggedIn && (
           <li className="profile-container">
-            <button className="profile-button" onClick={() => setOpen(!open)}>
+            <button className="profile-button" onClick={handleMenu}>
               <img src={userIcon} alt="User avatar" className="profile-avatar" />
             </button>
-            {open && (
-              <ul className="profile-dropdown">
-                <li>
-                  <Link to="/profile" onClick={() => setOpen(false)}>
-                    Profile
-                  </Link>
-                </li>
-                <li>
-                  <button onClick={handleLogout}>Log out</button>
-                </li>
-              </ul>
-            )}
+            <Menu
+              anchorEl={anchorEl}
+              open={open}
+              onClose={handleClose}
+              anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+              transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+            >
+              <MenuItem component={Link} to="/profile" onClick={handleClose}>
+                <ListItemIcon>
+                  <AccountCircle fontSize="small" />
+                </ListItemIcon>
+                Profile
+              </MenuItem>
+              <MenuItem onClick={handleLogout}>
+                <ListItemIcon>
+                  <Logout fontSize="small" />
+                </ListItemIcon>
+                Log out
+              </MenuItem>
+            </Menu>
           </li>
         )}
       </ul>

--- a/codespace/frontend/src/styles/ContactPage.css
+++ b/codespace/frontend/src/styles/ContactPage.css
@@ -1,14 +1,15 @@
 .contact-container {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  padding: 2rem 1rem;
+  min-height: 100vh;
   font-family: "Segoe UI", sans-serif;
 }
 
 .contact-content {
   width: 100%;
   max-width: 600px;
+  margin: 2rem auto;
+  padding: 0 1rem;
 }
 
 .contact-info {

--- a/codespace/frontend/src/styles/NavBar.css
+++ b/codespace/frontend/src/styles/NavBar.css
@@ -74,6 +74,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  border-radius: 50%;
 }
 
 .profile-avatar {
@@ -82,35 +83,6 @@
   border-radius: 50%;
 }
 
-.profile-dropdown {
-  position: absolute;
-  right: 0;
-  top: 100%;
-  background: #fff;
-  list-style: none;
-  margin: 0;
-  padding: 0.5rem 0;
-  border: 1px solid #ccc;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  border-radius: 4px;
-}
-
-.profile-dropdown li {
-  padding: 0.5rem 1rem;
-}
-
-.profile-dropdown li:hover {
-  background: #f0f0f0;
-}
-
-.profile-dropdown li a,
-.profile-dropdown li button {
-  background: none;
-  border: none;
-  text-decoration: none;
-  color: #333;
-  width: 100%;
-  text-align: left;
-  cursor: pointer;
-  font: inherit;
+.profile-button:hover {
+  background: rgba(255, 255, 255, 0.2);
 }


### PR DESCRIPTION
## Summary
- Prevent navbar resizing on Contact Us by restructuring layout
- Replace custom profile dropdown with Material UI menu and icons
- Add hover styling for profile button

## Testing
- `CI=true npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b4fe7b1c832883653a66557525e5