### PR TITLE
Let Room page content define height

### DIFF
--- a/codespace/frontend/src/styles/RoomPage.css
+++ b/codespace/frontend/src/styles/RoomPage.css
@@ -9,12 +9,10 @@
 }
 
 .room-wrapper {
-  flex: 1;
   display: flex;
 }
 
 .room-main {
-  flex: 1;
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -33,7 +31,6 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  min-height: 60vh;
 }
 
 .left-sidebar {


### PR DESCRIPTION
## Summary
- remove flex growth from Room page containers so height is content-driven
- drop fixed min-height on editor container
- keep page-level overflow-y auto for scrolling

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68a7bcff3728832899580b5fea9ac79a