### PR TITLE
Make room sidebar sticky and scrollable

### DIFF
--- a/codespace/frontend/src/styles/RoomPage.css
+++ b/codespace/frontend/src/styles/RoomPage.css
@@ -38,7 +38,10 @@
   display: flex;
   flex-direction: column;
   margin-right: 1rem;
-  height: 100%;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  overflow-y: auto;
 }
 
 .members-section {
@@ -59,6 +62,7 @@
   flex-direction: column;
   min-height: 0;
   margin-top: 1rem;
+  overflow-y: auto;
 }
 
 .chat-section .chat-container {


### PR DESCRIPTION
## Summary
- Keep room sidebar fixed using sticky positioning and full viewport height
- Allow chat sidebar to scroll independently

## Testing
- `CI=true npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68a7bdd5dd188328ae997dc3d91429ee