### PR TITLE
refactor: rely on server to append chat messages

### DIFF
--- a/codespace/frontend/src/components/ChatBox.js
+++ b/codespace/frontend/src/components/ChatBox.js
@@ -41,10 +41,7 @@ export default function ChatBox({ socket, username }) {
     const trimmed = message.trim();
     if (!trimmed || !socket) return;
     socket.emit('send-message', { msg: trimmed });
-    setMessages((prev) => [
-      ...prev.slice(-(MAX_MESSAGES - 1)),
-      { username, msg: trimmed },
-    ]);
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
     setMessage('');
   };
 


### PR DESCRIPTION
## Summary
- remove local message addition in ChatBox and let server broadcasts handle it
- keep auto-scroll to latest message when sending

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a7be85396c8328af2f3f1d569ed8e7