### PR TITLE
fix: improve room layout and scrolling

### DIFF
--- a/codespace/frontend/src/styles/RoomPage.css
+++ b/codespace/frontend/src/styles/RoomPage.css
@@ -17,6 +17,7 @@
   flex-direction: column;
   gap: 1rem;
   overflow: visible;
+  flex: 1;
 }
 
 .problem-view,
@@ -25,6 +26,8 @@
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   padding: 1rem;
+  flex: 1;
+  overflow-y: auto;
 }
 
 .editor-container {
@@ -122,5 +125,16 @@
 .leave-room-button:hover {
   background: #9a0007;
   transform: scale(1.03);
+}
+
+@media (min-width: 768px) {
+  .room-main {
+    flex-direction: row;
+  }
+
+  .problem-view,
+  .editor-container {
+    max-height: 90vh;
+  }
 }
 

--- a/codespace/frontend/src/styles/index.css
+++ b/codespace/frontend/src/styles/index.css
@@ -1,6 +1,7 @@
 body {
   margin: 0;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;


### PR DESCRIPTION
## Summary
- Make room layout responsive with side-by-side problem and editor
- Enable vertical scrolling for the application body

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a7c227e7f8832896db57a46f526224