### PR TITLE
Fix resource links and add topic management UI

### DIFF
--- a/codespace/frontend/src/pages/ResourcesPage.js
+++ b/codespace/frontend/src/pages/ResourcesPage.js
@@ -4,7 +4,7 @@ import NavBar from '../components/NavBar';
 import '../styles/ResourcesPage.css';
 import BACKEND_URL from '../config';
 
-const topics = {
+const initialTopics = {
   'Graph Algorithms': ['BFS', 'DFS'],
   'Dynamic Programming': ['Knapsack', 'LIS'],
 };
@@ -25,12 +25,17 @@ function ResourcesPage() {
   const [resources, setResources] = useState([]);
   const [openStatusId, setOpenStatusId] = useState(null);
   const [showForm, setShowForm] = useState(false);
+  const [showTopicForm, setShowTopicForm] = useState(false);
+  const [showSubtopicForm, setShowSubtopicForm] = useState(false);
   const [formData, setFormData] = useState({
     name: '',
     link: '',
     topic: '',
     subtopic: '',
   });
+  const [topics, setTopics] = useState(initialTopics);
+  const [newTopic, setNewTopic] = useState('');
+  const [newSubtopic, setNewSubtopic] = useState({ topic: '', name: '' });
 
   useEffect(() => {
     const fetchResources = async () => {
@@ -56,6 +61,26 @@ function ResourcesPage() {
       [name]: value,
       ...(name === 'topic' ? { subtopic: '' } : {}),
     }));
+  };
+
+  const addTopic = (e) => {
+    e.preventDefault();
+    if (!newTopic) return;
+    setTopics((prev) => ({ ...prev, [newTopic]: [] }));
+    setNewTopic('');
+    setShowTopicForm(false);
+  };
+
+  const addSubtopic = (e) => {
+    e.preventDefault();
+    const { topic, name } = newSubtopic;
+    if (!topic || !name) return;
+    setTopics((prev) => ({
+      ...prev,
+      [topic]: [...prev[topic], name],
+    }));
+    setNewSubtopic({ topic: '', name: '' });
+    setShowSubtopicForm(false);
   };
 
   const addResource = async (e) => {
@@ -102,7 +127,11 @@ function ResourcesPage() {
         </div>
         <div className="resources-content">
           <div className="left-menu">
-            <button onClick={() => setShowForm(!showForm)}>New</button>
+            <div className="button-group">
+              <button onClick={() => setShowForm(!showForm)}>New</button>
+              <button onClick={() => setShowTopicForm(!showTopicForm)}>New Topic</button>
+              <button onClick={() => setShowSubtopicForm(!showSubtopicForm)}>New Subtopic</button>
+            </div>
             {showForm && (
               <form className="add-resource-form" onSubmit={addResource}>
                 <input
@@ -147,6 +176,46 @@ function ResourcesPage() {
                 <button type="submit">Add</button>
               </form>
             )}
+            {showTopicForm && (
+              <form className="add-topic-form" onSubmit={addTopic}>
+                <input
+                  type="text"
+                  value={newTopic}
+                  onChange={(e) => setNewTopic(e.target.value)}
+                  placeholder="Topic Name"
+                  required
+                />
+                <button type="submit">Add</button>
+              </form>
+            )}
+            {showSubtopicForm && (
+              <form className="add-subtopic-form" onSubmit={addSubtopic}>
+                <select
+                  value={newSubtopic.topic}
+                  onChange={(e) =>
+                    setNewSubtopic((prev) => ({ ...prev, topic: e.target.value }))
+                  }
+                  required
+                >
+                  <option value="">Select Topic</option>
+                  {Object.keys(topics).map((topic) => (
+                    <option key={topic} value={topic}>
+                      {topic}
+                    </option>
+                  ))}
+                </select>
+                <input
+                  type="text"
+                  value={newSubtopic.name}
+                  onChange={(e) =>
+                    setNewSubtopic((prev) => ({ ...prev, name: e.target.value }))
+                  }
+                  placeholder="Subtopic Name"
+                  required
+                />
+                <button type="submit">Add</button>
+              </form>
+            )}
             <select value={selectedTopic} onChange={handleTopicChange}>
               <option value="">All Topics</option>
               {Object.keys(topics).map((topic) => (
@@ -159,9 +228,12 @@ function ResourcesPage() {
               disabled={!selectedTopic}
             >
               <option value="">All Subtopics</option>
-              {selectedTopic && topics[selectedTopic].map((sub) => (
-                <option key={sub} value={sub}>{sub}</option>
-              ))}
+              {selectedTopic &&
+                topics[selectedTopic].map((sub) => (
+                  <option key={sub} value={sub}>
+                    {sub}
+                  </option>
+                ))}
             </select>
           </div>
           <div className="right-resources">
@@ -172,7 +244,13 @@ function ResourcesPage() {
                 <div
                   key={res._id}
                   className="resource-card"
-                  onClick={() => window.open(res.link, '_blank', 'noopener,noreferrer')}
+                  onClick={() => {
+                    const link =
+                      res.link.startsWith('http://') || res.link.startsWith('https://')
+                        ? res.link
+                        : `https://${res.link}`;
+                    window.open(link, '_blank', 'noopener,noreferrer');
+                  }}
                 >
                   <div className="resource-header">
                     <h3>{res.name}</h3>

--- a/codespace/frontend/src/styles/ResourcesPage.css
+++ b/codespace/frontend/src/styles/ResourcesPage.css
@@ -46,6 +46,18 @@
   cursor: pointer;
 }
 
+.button-group {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 15px;
+}
+
+.button-group button {
+  width: auto;
+  margin-bottom: 0;
+  flex: 1;
+}
+
 .add-resource-form input,
 .add-resource-form select,
 .add-resource-form button {
@@ -57,6 +69,24 @@
 }
 
 .add-resource-form button {
+  background: #3b82f6;
+  color: #fff;
+}
+
+.add-topic-form input,
+.add-topic-form button,
+.add-subtopic-form select,
+.add-subtopic-form input,
+.add-subtopic-form button {
+  width: 100%;
+  padding: 8px;
+  margin-bottom: 10px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+}
+
+.add-topic-form button,
+.add-subtopic-form button {
   background: #3b82f6;
   color: #fff;
 }


### PR DESCRIPTION
## Summary
- Ensure resource cards open the correct URL by prefixing missing protocols
- Add topic and subtopic management buttons and forms to resources page
- Style new controls for a horizontal button group and associated forms

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a866893cec8328a1865ac9015dc022