### PR TITLE
Fix resource links and add topic management UI

### DIFF
--- a/codespace/frontend/src/pages/ResourcesPage.js
+++ b/codespace/frontend/src/pages/ResourcesPage.js
@@ -4,11 +4,6 @@ import NavBar from '../components/NavBar';
 import '../styles/ResourcesPage.css';
 import BACKEND_URL from '../config';
 
-const topics = {
-  'Graph Algorithms': ['BFS', 'DFS'],
-  'Dynamic Programming': ['Knapsack', 'LIS'],
-};
-
 const statusOptions = [
   { value: 'Not Attempted', emoji: '⏳' },
   { value: 'Solving', emoji: '🧠' },
@@ -25,12 +20,17 @@ function ResourcesPage() {
   const [resources, setResources] = useState([]);
   const [openStatusId, setOpenStatusId] = useState(null);
   const [showForm, setShowForm] = useState(false);
+  const [showTopicForm, setShowTopicForm] = useState(false);
+  const [showSubtopicForm, setShowSubtopicForm] = useState(false);
   const [formData, setFormData] = useState({
     name: '',
     link: '',
     topic: '',
     subtopic: '',
   });
+  const [topics, setTopics] = useState({});
+  const [newTopic, setNewTopic] = useState('');
+  const [newSubtopic, setNewSubtopic] = useState({ topic: '', name: '' });
 
   useEffect(() => {
     const fetchResources = async () => {
@@ -42,6 +42,18 @@ function ResourcesPage() {
       }
     };
     fetchResources();
+  }, []);
+
+  useEffect(() => {
+    const fetchTopics = async () => {
+      try {
+        const res = await axios.get(`${BACKEND_URL}/api/topics`);
+        setTopics(res.data);
+      } catch (err) {
+        console.error('Failed to fetch topics', err);
+      }
+    };
+    fetchTopics();
   }, []);
 
   const handleTopicChange = (e) => {
@@ -56,6 +68,36 @@ function ResourcesPage() {
       [name]: value,
       ...(name === 'topic' ? { subtopic: '' } : {}),
     }));
+  };
+
+  const addTopic = async (e) => {
+    e.preventDefault();
+    if (!newTopic) return;
+    try {
+      await axios.post(`${BACKEND_URL}/api/topics`, { topic: newTopic });
+      setTopics((prev) => ({ ...prev, [newTopic]: [] }));
+      setNewTopic('');
+      setShowTopicForm(false);
+    } catch (err) {
+      console.error('Failed to add topic', err);
+    }
+  };
+
+  const addSubtopic = async (e) => {
+    e.preventDefault();
+    const { topic, name } = newSubtopic;
+    if (!topic || !name) return;
+    try {
+      await axios.post(`${BACKEND_URL}/api/topics`, { topic, subtopic: name });
+      setTopics((prev) => ({
+        ...prev,
+        [topic]: [...prev[topic], name],
+      }));
+      setNewSubtopic({ topic: '', name: '' });
+      setShowSubtopicForm(false);
+    } catch (err) {
+      console.error('Failed to add subtopic', err);
+    }
   };
 
   const addResource = async (e) => {
@@ -102,7 +144,11 @@ function ResourcesPage() {
         </div>
         <div className="resources-content">
           <div className="left-menu">
-            <button onClick={() => setShowForm(!showForm)}>New</button>
+            <div className="button-group">
+              <button onClick={() => setShowForm(!showForm)}>New</button>
+              <button onClick={() => setShowTopicForm(!showTopicForm)}>New Topic</button>
+              <button onClick={() => setShowSubtopicForm(!showSubtopicForm)}>New Subtopic</button>
+            </div>
             {showForm && (
               <form className="add-resource-form" onSubmit={addResource}>
                 <input
@@ -140,10 +186,50 @@ function ResourcesPage() {
                   required
                 >
                   <option value="">Select Subtopic</option>
-                  {formData.topic && topics[formData.topic].map((sub) => (
-                    <option key={sub} value={sub}>{sub}</option>
+                    {formData.topic && (topics[formData.topic] || []).map((sub) => (
+                      <option key={sub} value={sub}>{sub}</option>
+                    ))}
+                </select>
+                <button type="submit">Add</button>
+              </form>
+            )}
+            {showTopicForm && (
+              <form className="add-topic-form" onSubmit={addTopic}>
+                <input
+                  type="text"
+                  value={newTopic}
+                  onChange={(e) => setNewTopic(e.target.value)}
+                  placeholder="Topic Name"
+                  required
+                />
+                <button type="submit">Add</button>
+              </form>
+            )}
+            {showSubtopicForm && (
+              <form className="add-subtopic-form" onSubmit={addSubtopic}>
+                <select
+                  value={newSubtopic.topic}
+                  onChange={(e) =>
+                    setNewSubtopic((prev) => ({ ...prev, topic: e.target.value }))
+                  }
+                  required
+                >
+                  <option value="">Select Topic</option>
+                  {Object.keys(topics).map((topic) => (
+                    <option key={topic} value={topic}>
+                      {topic}
+                    </option>
                   ))}
                 </select>
+                <input
+                  type="text"
+                  value={newSubtopic.name}
+                  onChange={(e) =>
+                    setNewSubtopic((prev) => ({ ...prev, name: e.target.value }))
+                  }
+                  placeholder="Subtopic Name"
+                  required
+                />
                 <button type="submit">Add</button>
               </form>
             )}
@@ -159,9 +245,12 @@ function ResourcesPage() {
               disabled={!selectedTopic}
             >
               <option value="">All Subtopics</option>
-              {selectedTopic && topics[selectedTopic].map((sub) => (
-                <option key={sub} value={sub}>{sub}</option>
-              ))}
+              {selectedTopic &&
+                (topics[selectedTopic] || []).map((sub) => (
+                  <option key={sub} value={sub}>
+                    {sub}
+                  </option>
+                ))}
             </select>
           </div>
           <div className="right-resources">
@@ -172,7 +261,13 @@ function ResourcesPage() {
                 <div
                   key={res._id}
                   className="resource-card"
-                  onClick={() => window.open(res.link, '_blank', 'noopener,noreferrer')}
+                  onClick={() => {
+                    const link =
+                      res.link.startsWith('http://') || res.link.startsWith('https://')
+                        ? res.link
+                        : `https://${res.link}`;
+                    window.open(link, '_blank', 'noopener,noreferrer');
+                  }}
                 >
                   <div className="resource-header">
                     <h3>{res.name}</h3>

--- a/codespace/frontend/src/styles/ResourcesPage.css
+++ b/codespace/frontend/src/styles/ResourcesPage.css
@@ -46,6 +46,18 @@
   cursor: pointer;
 }
 
+.button-group {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 15px;
+}
+
+.button-group button {
+  width: auto;
+  margin-bottom: 0;
+  flex: 1;
+}
+
 .add-resource-form input,
 .add-resource-form select,
 .add-resource-form button {
@@ -57,6 +69,24 @@
 }
 
 .add-resource-form button {
+  background: #3b82f6;
+  color: #fff;
+}
+
+.add-topic-form input,
+.add-topic-form button,
+.add-subtopic-form select,
+.add-subtopic-form input,
+.add-subtopic-form button {
+  width: 100%;
+  padding: 8px;
+  margin-bottom: 10px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+}
+
+.add-topic-form button,
+.add-subtopic-form button {
   background: #3b82f6;
   color: #fff;
 }

--- a/codespace/server/app.js
+++ b/codespace/server/app.js
@@ -12,6 +12,7 @@ const contestsRoute = require("./routes/contests")
 const authMiddleware = require("./middleware/authMiddleware")
 const usersRoute = require("./routes/users")
 const resourcesRoute = require("./routes/resources")
+const topicsRoute = require("./routes/topics")
 const rateLimit = require('express-rate-limit');
 
 const app = express();
@@ -41,6 +42,7 @@ app.use('/api/contests',contestsRoute)
 app.use('/api/rooms', authMiddleware, roomsRoute)
 app.use('/api/users', usersRoute)
 app.use('/api/resources', resourcesRoute)
+app.use('/api/topics', topicsRoute)
 app.use('/test',test)
 app.use('/submit',submit)
 

--- a/codespace/server/model/topicModel.js
+++ b/codespace/server/model/topicModel.js
@@ -1,0 +1,17 @@
+const mongoose = require('mongoose');
+
+const topicSchema = new mongoose.Schema({
+  topic: { type: String, required: true },
+  subtopic: { type: String, default: '' }
+});
+
+// Ensure combination of topic and subtopic is unique
+// This acts like a composite primary key
+// Index prevents duplicates for same topic-subtopic pair
+
+// Create compound index with unique constraint
+// Equivalent of composite primary key in relational DB
+//   { topic, subtopic }
+topicSchema.index({ topic: 1, subtopic: 1 }, { unique: true });
+
+module.exports = mongoose.model('Topic', topicSchema);

--- a/codespace/server/routes/topics.js
+++ b/codespace/server/routes/topics.js
@@ -1,0 +1,41 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const Topic = require('../model/topicModel');
+
+const router = express.Router();
+const url = process.env.MONGODB_URI || 'mongodb://localhost:27017/graduation_project';
+
+mongoose.connect(url);
+
+// Get all topics grouped with their subtopics
+router.get('/', async (req, res) => {
+  try {
+    const topics = await Topic.find();
+    const grouped = {};
+    topics.forEach(({ topic, subtopic }) => {
+      if (!grouped[topic]) grouped[topic] = [];
+      if (subtopic) grouped[topic].push(subtopic);
+    });
+    res.json(grouped);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch topics' });
+  }
+});
+
+// Add a topic or subtopic
+router.post('/', async (req, res) => {
+  try {
+    const { topic, subtopic = '' } = req.body;
+    const newTopic = new Topic({ topic, subtopic });
+    await newTopic.save();
+    res.status(201).json(newTopic);
+  } catch (err) {
+    if (err.code === 11000) {
+      res.status(409).json({ error: 'Topic and subtopic already exist' });
+    } else {
+      res.status(500).json({ error: 'Failed to save topic' });
+    }
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- Ensure resource cards open the correct URL by prefixing missing protocols
- Add topic and subtopic management buttons and forms to resources page
- Style new controls for a horizontal button group and associated forms
- Persist topics and subtopics in a dedicated database collection with API endpoints

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a866893cec8328a1865ac9015dc022