### PR TITLE
fix: provide default redis url

### DIFF
--- a/codespace/server/jobs/webScrapingWorker.js
+++ b/codespace/server/jobs/webScrapingWorker.js
@@ -4,11 +4,12 @@ const {redisClient} = require('../model/redisModel')
 const {execFile} = require('child_process');
 const { stderr } = require('process');
 
-const redis_url = process.env.REDIS_URL; 
+// Allow configuration of the Redis connection while providing sensible defaults.
+// Log the final URL so developers can verify which endpoint is being used.
+const redis_url = process.env.REDIS_URL || 'redis://localhost:6379';
 console.log("Redis URL:", redis_url);
 
-// Allow configuration of the Redis connection while providing sensible defaults
-const { hostname: redisHost, port: redisPort } = new URL(process.env.REDIS_URL || 'redis://localhost:6379');
+const { hostname: redisHost, port: redisPort } = new URL(redis_url);
 const connectionOptions = {
     host: redisHost,
     port: parseInt(redisPort, 10)


### PR DESCRIPTION
## Summary
- avoid undefined Redis URL by falling back to localhost and logging used URL

## Testing
- `node jobs/webScrapingWorker.js` *(fails: connect ECONNREFUSED 127.0.0.1:6379)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a0e374a0832897d018d2bd4f62a9