### PR TITLE
Add topic endpoints and integrate with resources

### DIFF
--- a/codespace/frontend/src/pages/ResourcesPage.js
+++ b/codespace/frontend/src/pages/ResourcesPage.js
@@ -4,10 +4,6 @@ import NavBar from '../components/NavBar';
 import '../styles/ResourcesPage.css';
 import BACKEND_URL from '../config';
 
-const initialTopics = {
-  'Graph Algorithms': ['BFS', 'DFS'],
-  'Dynamic Programming': ['Knapsack', 'LIS'],
-};
 
 const statusOptions = [
   { value: 'Not Attempted', emoji: '⏳' },
@@ -33,7 +29,7 @@ function ResourcesPage() {
     topic: '',
     subtopic: '',
   });
-  const [topics, setTopics] = useState(initialTopics);
+  const [topics, setTopics] = useState({});
   const [newTopic, setNewTopic] = useState('');
   const [newSubtopic, setNewSubtopic] = useState({ topic: '', name: '' });
 
@@ -46,7 +42,16 @@ function ResourcesPage() {
         console.error('Failed to fetch resources', err);
       }
     };
+    const fetchTopics = async () => {
+      try {
+        const res = await axios.get(`${BACKEND_URL}/api/topics`);
+        setTopics(res.data);
+      } catch (err) {
+        console.error('Failed to fetch topics', err);
+      }
+    };
     fetchResources();
+    fetchTopics();
   }, []);
 
   const handleTopicChange = (e) => {
@@ -63,24 +68,34 @@ function ResourcesPage() {
     }));
   };
 
-  const addTopic = (e) => {
+  const addTopic = async (e) => {
     e.preventDefault();
     if (!newTopic) return;
-    setTopics((prev) => ({ ...prev, [newTopic]: [] }));
-    setNewTopic('');
-    setShowTopicForm(false);
+    try {
+      await axios.post(`${BACKEND_URL}/api/topics`, { topic: newTopic });
+      setTopics((prev) => ({ ...prev, [newTopic]: [] }));
+      setNewTopic('');
+      setShowTopicForm(false);
+    } catch (err) {
+      console.error('Failed to add topic', err);
+    }
   };
 
-  const addSubtopic = (e) => {
+  const addSubtopic = async (e) => {
     e.preventDefault();
     const { topic, name } = newSubtopic;
     if (!topic || !name) return;
-    setTopics((prev) => ({
-      ...prev,
-      [topic]: [...prev[topic], name],
-    }));
-    setNewSubtopic({ topic: '', name: '' });
-    setShowSubtopicForm(false);
+    try {
+      await axios.post(`${BACKEND_URL}/api/topics`, { topic, subtopic: name });
+      setTopics((prev) => ({
+        ...prev,
+        [topic]: [...prev[topic], name],
+      }));
+      setNewSubtopic({ topic: '', name: '' });
+      setShowSubtopicForm(false);
+    } catch (err) {
+      console.error('Failed to add subtopic', err);
+    }
   };
 
   const addResource = async (e) => {

--- a/codespace/server/app.js
+++ b/codespace/server/app.js
@@ -11,7 +11,8 @@ const roomsRoute = require("./routes/rooms");
 const contestsRoute = require("./routes/contests")
 const authMiddleware = require("./middleware/authMiddleware")
 const usersRoute = require("./routes/users")
-const resourcesRoute = require("./routes/resources")
+const resourcesRoute = require("./routes/resources");
+const topicsRoute = require("./routes/topics");
 const rateLimit = require('express-rate-limit');
 
 const app = express();
@@ -41,6 +42,7 @@ app.use('/api/contests',contestsRoute)
 app.use('/api/rooms', authMiddleware, roomsRoute)
 app.use('/api/users', usersRoute)
 app.use('/api/resources', resourcesRoute)
+app.use('/api/topics', topicsRoute)
 app.use('/test',test)
 app.use('/submit',submit)
 

--- a/codespace/server/model/topicModel.js
+++ b/codespace/server/model/topicModel.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 
 const topicSchema = new mongoose.Schema({
   topic: { type: String, required: true },
-  subtopic: { type: String, required: true }
+  subtopic: { type: String }
 });
 
 // Ensure each topic/subtopic pair is unique

--- a/codespace/server/routes/topics.js
+++ b/codespace/server/routes/topics.js
@@ -1,0 +1,38 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const Topic = require('../model/topicModel');
+
+const router = express.Router();
+const url = process.env.MONGODB_URI || 'mongodb://localhost:27017/graduation_project';
+
+mongoose.connect(url);
+
+router.get('/', async (req, res) => {
+  try {
+    const topics = await Topic.find();
+    const formatted = topics.reduce((acc, { topic, subtopic }) => {
+      if (!acc[topic]) acc[topic] = [];
+      if (subtopic) acc[topic].push(subtopic);
+      return acc;
+    }, {});
+    res.json(formatted);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch topics' });
+  }
+});
+
+router.post('/', async (req, res) => {
+  try {
+    const { topic, subtopic } = req.body;
+    await Topic.updateOne(
+      { topic, subtopic },
+      { topic, subtopic },
+      { upsert: true }
+    );
+    res.status(201).json({ topic, subtopic });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to save topic' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- Allow topics to exist without subtopics in the database
- Add API to fetch and create topics
- Load and create topics/subtopics on the Resources page

## Testing
- `npm test` (server) *(fails: Missing script: "test")*
- `CI=true npm test` (frontend) *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a1e7d53c83289ab6c1f7235f17f7