### PR TITLE
Check Docker availability for code execution sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,11 @@ npm start
 
 Adjust any variables in the `.env` files if your local services run on different
 hosts or ports.
+
+### Code execution sandbox
+
+The `/test` endpoint compiles and runs user-submitted C++ code inside a
+throwaway Docker container for isolation. Make sure the Docker daemon is
+available and the `docker` CLI is installed on the machine running the API
+server. If the CLI lives at a non-default path, set the `DOCKER_CMD`
+environment variable to the desired executable before starting the server.


### PR DESCRIPTION
## Summary
- ensure `/test` endpoint verifies Docker is installed before spawning containers
- allow overriding Docker binary via `DOCKER_CMD` env variable
- document Docker requirement for code execution sandbox

## Testing
- `npm test` (server) *(fails: Missing script: "test")*
- `CI=true npm test -- --watchAll=false` (frontend) *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f48177248328b377a511cde20bca