### PR TITLE
Fix test route workspace path to ensure C++ compilation

### DIFF
--- a/codespace/server/routes/test.js
+++ b/codespace/server/routes/test.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const path = require('path');
 const fs = require('fs').promises;
-const os = require('os');
 const { spawn, exec } = require('child_process');
 const util = require('util');
 const execAsync = util.promisify(exec);
@@ -30,7 +29,9 @@ router.post('/', async (req, res) => {
     return res.status(500).send('Docker is not installed or not in PATH');
   }
 
-  const tmpBase = path.join(os.tmpdir(), 'sandbox-');
+  const tmpDir = path.join(__dirname, '..', 'test-data');
+  await fs.mkdir(tmpDir, { recursive: true });
+  const tmpBase = path.join(tmpDir, 'sandbox-');
   let workDir;
 
   try {


### PR DESCRIPTION
## Summary
- ensure test route creates temp directory inside project for Docker volume

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8f7b522b0832882645daac0d7f76a