### PR TITLE
Mount test data directory for sandboxed code execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,6 @@ throwaway Docker container for isolation. Make sure the Docker daemon is
 available and the `docker` CLI is installed on the machine running the API
 server. If the CLI lives at a non-default path, set the `DOCKER_CMD`
 environment variable to the desired executable before starting the server.
+The `codespace/server/test-data` directory is bind-mounted into the server
+container, ensuring the Docker daemon can access temporary source files created
+for compilation.

--- a/codespace/server/routes/test.js
+++ b/codespace/server/routes/test.js
@@ -29,9 +29,9 @@ router.post('/', async (req, res) => {
     return res.status(500).send('Docker is not installed or not in PATH');
   }
 
-  const tmpDir = path.join(__dirname, '..', 'test-data');
-  await fs.mkdir(tmpDir, { recursive: true });
-  const tmpBase = path.join(tmpDir, 'sandbox-');
+  const TEST_DATA_DIR = process.env.TEST_DATA_DIR || path.join(__dirname, '..', 'test-data');
+  await fs.mkdir(TEST_DATA_DIR, { recursive: true });
+  const tmpBase = path.join(TEST_DATA_DIR, 'sandbox-');
   let workDir;
 
   try {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     depends_on: [mongo, redis]
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - ./codespace/server/test-data:/app/test-data
   frontend:
     build: ./codespace/frontend
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- mount `codespace/server/test-data` into the server container so Docker can see generated source files
- allow `/test` route to honor `TEST_DATA_DIR` env var when creating sandboxes
- document bind mount requirement in README

## Testing
- `node -e "require('./codespace/server/routes/test'); console.log('module loaded')"`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fd7a63408328a06fb41790f27ea7