### PR TITLE
Add problem management section with table and API

### DIFF
--- a/codespace/frontend/src/components/ProblemSidebar.js
+++ b/codespace/frontend/src/components/ProblemSidebar.js
@@ -1,0 +1,150 @@
+import React from 'react';
+
+function ProblemSidebar({
+  showForm,
+  setShowForm,
+  showTopicForm,
+  setShowTopicForm,
+  showSubtopicForm,
+  setShowSubtopicForm,
+  formData,
+  handleFormChange,
+  addProblem,
+  topics,
+  newTopic,
+  setNewTopic,
+  addTopic,
+  newSubtopic,
+  setNewSubtopic,
+  addSubtopic,
+  selectedTopic,
+  handleTopicChange,
+  selectedSubtopic,
+  setSelectedSubtopic,
+}) {
+  return (
+    <div className="left-menu">
+      <div className="button-group">
+        <button onClick={() => setShowForm(!showForm)}>New Problem</button>
+        <button onClick={() => setShowTopicForm(!showTopicForm)}>New Topic</button>
+        <button onClick={() => setShowSubtopicForm(!showSubtopicForm)}>New Subtopic</button>
+      </div>
+      {showForm && (
+        <form className="add-resource-form" onSubmit={addProblem}>
+          <input
+            type="text"
+            name="name"
+            placeholder="Name"
+            value={formData.name}
+            onChange={handleFormChange}
+            required
+          />
+          <input
+            type="text"
+            name="link"
+            placeholder="Link"
+            value={formData.link}
+            onChange={handleFormChange}
+            required
+          />
+          <select
+            name="topic"
+            value={formData.topic}
+            onChange={handleFormChange}
+            required
+          >
+            <option value="">Select Topic</option>
+            {Object.keys(topics).map((topic) => (
+              <option key={topic} value={topic}>
+                {topic}
+              </option>
+            ))}
+          </select>
+          <select
+            name="subtopic"
+            value={formData.subtopic}
+            onChange={handleFormChange}
+            disabled={!formData.topic}
+            required
+          >
+            <option value="">Select Subtopic</option>
+            {formData.topic &&
+              topics[formData.topic].map((sub) => (
+                <option key={sub} value={sub}>
+                  {sub}
+                </option>
+              ))}
+          </select>
+          <input
+            type="text"
+            name="difficulty"
+            placeholder="Difficulty"
+            value={formData.difficulty}
+            onChange={handleFormChange}
+            required
+          />
+          <button type="submit">Add</button>
+        </form>
+      )}
+      {showTopicForm && (
+        <form className="add-topic-form" onSubmit={addTopic}>
+          <input
+            type="text"
+            value={newTopic}
+            onChange={(e) => setNewTopic(e.target.value)}
+            placeholder="Topic Name"
+            required
+          />
+          <button type="submit">Add</button>
+        </form>
+      )}
+      {showSubtopicForm && (
+        <form className="add-subtopic-form" onSubmit={addSubtopic}>
+          <select
+            value={newSubtopic.topic}
+            onChange={(e) => setNewSubtopic((prev) => ({ ...prev, topic: e.target.value }))}
+            required
+          >
+            <option value="">Select Topic</option>
+            {Object.keys(topics).map((topic) => (
+              <option key={topic} value={topic}>
+                {topic}
+              </option>
+            ))}
+          </select>
+          <input
+            type="text"
+            value={newSubtopic.name}
+            onChange={(e) => setNewSubtopic((prev) => ({ ...prev, name: e.target.value }))}
+            placeholder="Subtopic Name"
+            required
+          />
+          <button type="submit">Add</button>
+        </form>
+      )}
+      <select value={selectedTopic} onChange={handleTopicChange}>
+        <option value="">All Topics</option>
+        {Object.keys(topics).map((topic) => (
+          <option key={topic} value={topic}>
+            {topic}
+          </option>
+        ))}
+      </select>
+      <select
+        value={selectedSubtopic}
+        onChange={(e) => setSelectedSubtopic(e.target.value)}
+        disabled={!selectedTopic}
+      >
+        <option value="">All Subtopics</option>
+        {selectedTopic &&
+          topics[selectedTopic].map((sub) => (
+            <option key={sub} value={sub}>
+              {sub}
+            </option>
+          ))}
+      </select>
+    </div>
+  );
+}
+
+export default ProblemSidebar;

--- a/codespace/frontend/src/components/ProblemTable.js
+++ b/codespace/frontend/src/components/ProblemTable.js
@@ -1,0 +1,57 @@
+import React, { useState } from 'react';
+
+function ProblemTable({ problems }) {
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 10;
+  const totalPages = Math.ceil(problems.length / itemsPerPage) || 1;
+
+  const openLink = (link) => {
+    const url = link.startsWith('http://') || link.startsWith('https://')
+      ? link
+      : `https://${link}`;
+    window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
+  const current = problems.slice(
+    (currentPage - 1) * itemsPerPage,
+    currentPage * itemsPerPage
+  );
+
+  return (
+    <div className="right-problems">
+      <table className="problem-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Topic</th>
+            <th>Subtopic</th>
+            <th>Difficulty</th>
+          </tr>
+        </thead>
+        <tbody>
+          {current.map((p) => (
+            <tr key={p._id} onClick={() => openLink(p.link)}>
+              <td>{p.name}</td>
+              <td>{p.topic}</td>
+              <td>{p.subtopic}</td>
+              <td>{p.difficulty}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="pagination">
+        {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+          <button
+            key={page}
+            onClick={() => setCurrentPage(page)}
+            className={page === currentPage ? 'active' : ''}
+          >
+            {page}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default ProblemTable;

--- a/codespace/frontend/src/pages/ProblemsPage.js
+++ b/codespace/frontend/src/pages/ProblemsPage.js
@@ -1,42 +1,152 @@
-import React, { useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import NavBar from '../components/NavBar';
+import '../styles/ProblemsPage.css';
 import BACKEND_URL from '../config';
-
-// Custom hook to fetch the list of problems from the backend
-function useProblemList() {
-  const [problems, setProblems] = useState([]);
-
-  useEffect(() => {
-    async function fetchProblems() {
-      try {
-        const res = await axios.get(`${BACKEND_URL}/api/problem-list`);
-        setProblems(res.data);
-      } catch (err) {
-        console.error('Error fetching problems:', err);
-      }
-    }
-    fetchProblems();
-  }, []);
-
-  return problems;
-}
+import ProblemSidebar from '../components/ProblemSidebar';
+import ProblemTable from '../components/ProblemTable';
 
 function ProblemsPage() {
-  const problems = useProblemList();
+  const [search, setSearch] = useState('');
+  const [selectedTopic, setSelectedTopic] = useState('');
+  const [selectedSubtopic, setSelectedSubtopic] = useState('');
+  const [problems, setProblems] = useState([]);
+  const [showForm, setShowForm] = useState(false);
+  const [showTopicForm, setShowTopicForm] = useState(false);
+  const [showSubtopicForm, setShowSubtopicForm] = useState(false);
+  const [formData, setFormData] = useState({
+    name: '',
+    link: '',
+    topic: '',
+    subtopic: '',
+    difficulty: '',
+  });
+  const [topics, setTopics] = useState({});
+  const [newTopic, setNewTopic] = useState('');
+  const [newSubtopic, setNewSubtopic] = useState({ topic: '', name: '' });
+
+  useEffect(() => {
+    const fetchProblems = async () => {
+      try {
+        const res = await axios.get(`${BACKEND_URL}/api/problems`);
+        setProblems(res.data);
+      } catch (err) {
+        console.error('Failed to fetch problems', err);
+      }
+    };
+    const fetchTopics = async () => {
+      try {
+        const res = await axios.get(`${BACKEND_URL}/api/topics`);
+        setTopics(res.data);
+      } catch (err) {
+        console.error('Failed to fetch topics', err);
+      }
+    };
+    fetchProblems();
+    fetchTopics();
+  }, []);
+
+  const handleTopicChange = (e) => {
+    setSelectedTopic(e.target.value);
+    setSelectedSubtopic('');
+  };
+
+  const handleFormChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({
+      ...prev,
+      [name]: value,
+      ...(name === 'topic' ? { subtopic: '' } : {}),
+    }));
+  };
+
+  const addTopic = async (e) => {
+    e.preventDefault();
+    if (!newTopic) return;
+    try {
+      await axios.post(`${BACKEND_URL}/api/topics`, { topic: newTopic });
+      setTopics((prev) => ({ ...prev, [newTopic]: [] }));
+      setNewTopic('');
+      setShowTopicForm(false);
+    } catch (err) {
+      console.error('Failed to add topic', err);
+    }
+  };
+
+  const addSubtopic = async (e) => {
+    e.preventDefault();
+    const { topic, name } = newSubtopic;
+    if (!topic || !name) return;
+    try {
+      await axios.post(`${BACKEND_URL}/api/topics`, { topic, subtopic: name });
+      setTopics((prev) => ({
+        ...prev,
+        [topic]: [...prev[topic], name],
+      }));
+      setNewSubtopic({ topic: '', name: '' });
+      setShowSubtopicForm(false);
+    } catch (err) {
+      console.error('Failed to add subtopic', err);
+    }
+  };
+
+  const addProblem = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await axios.post(`${BACKEND_URL}/api/problems`, formData);
+      setProblems((prev) => [...prev, res.data]);
+      setFormData({ name: '', link: '', topic: '', subtopic: '', difficulty: '' });
+      setShowForm(false);
+    } catch (err) {
+      console.error('Failed to add problem', err);
+    }
+  };
+
+  const filteredProblems = problems.filter((p) => {
+    const matchesTopic = selectedTopic ? p.topic === selectedTopic : true;
+    const matchesSubtopic = selectedSubtopic ? p.subtopic === selectedSubtopic : true;
+    const matchesSearch = p.name.toLowerCase().includes(search.toLowerCase());
+    return matchesTopic && matchesSubtopic && matchesSearch;
+  });
 
   return (
     <div>
       <NavBar />
-      <h1>Problems Page</h1>
-      <ul>
-        {problems.map((problem) => (
-          <li key={problem.id}>
-            {problem.problem_name} <Link to={`/problems/${problem.id}`}>View</Link>
-          </li>
-        ))}
-      </ul>
+      <div className="problems-page">
+        <div className="search-bar">
+          <input
+            type="text"
+            placeholder="Search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+        <div className="problems-content">
+          <ProblemSidebar
+            showForm={showForm}
+            setShowForm={setShowForm}
+            showTopicForm={showTopicForm}
+            setShowTopicForm={setShowTopicForm}
+            showSubtopicForm={showSubtopicForm}
+            setShowSubtopicForm={setShowSubtopicForm}
+            formData={formData}
+            handleFormChange={handleFormChange}
+            addProblem={addProblem}
+            topics={topics}
+            newTopic={newTopic}
+            setNewTopic={setNewTopic}
+            addTopic={addTopic}
+            newSubtopic={newSubtopic}
+            setNewSubtopic={setNewSubtopic}
+            addSubtopic={addSubtopic}
+            selectedTopic={selectedTopic}
+            handleTopicChange={handleTopicChange}
+            selectedSubtopic={selectedSubtopic}
+            setSelectedSubtopic={setSelectedSubtopic}
+          />
+          <ProblemTable problems={filteredProblems} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/codespace/frontend/src/styles/ProblemsPage.css
+++ b/codespace/frontend/src/styles/ProblemsPage.css
@@ -1,0 +1,142 @@
+.problems-page {
+  display: flex;
+  flex-direction: column;
+  padding: 20px;
+}
+
+.search-bar {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 20px;
+}
+
+.search-bar input {
+  width: 100%;
+  max-width: 600px;
+  padding: 10px 15px;
+  border-radius: 8px;
+  border: 1px solid #ccc;
+}
+
+.problems-content {
+  display: flex;
+  height: 80vh;
+}
+
+.left-menu {
+  width: 25%;
+  padding-right: 20px;
+  overflow-y: auto;
+  height: 100%;
+}
+
+.left-menu select {
+  width: 100%;
+  padding: 8px;
+  margin-bottom: 15px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+}
+
+.left-menu button {
+  width: 100%;
+  padding: 8px;
+  margin-bottom: 15px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  background: #1f2937;
+  color: #f1f5f9;
+  cursor: pointer;
+}
+
+.button-group {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 15px;
+}
+
+.button-group button {
+  width: auto;
+  margin-bottom: 0;
+  flex: 1;
+}
+
+.add-resource-form input,
+.add-resource-form select,
+.add-resource-form button {
+  width: 100%;
+  padding: 8px;
+  margin-bottom: 10px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+}
+
+.add-resource-form button {
+  background: #3b82f6;
+  color: #fff;
+}
+
+.add-topic-form input,
+.add-topic-form button,
+.add-subtopic-form select,
+.add-subtopic-form input,
+.add-subtopic-form button {
+  width: 100%;
+  padding: 8px;
+  margin-bottom: 10px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+}
+
+.add-topic-form button,
+.add-subtopic-form button {
+  background: #3b82f6;
+  color: #fff;
+}
+
+.right-problems {
+  width: 75%;
+  overflow-y: auto;
+  height: 100%;
+}
+
+.problem-table {
+  width: 100%;
+  border-collapse: collapse;
+  color: #f1f5f9;
+}
+
+.problem-table th,
+.problem-table td {
+  border: 1px solid #444;
+  padding: 8px;
+  text-align: left;
+}
+
+.problem-table tr {
+  cursor: pointer;
+}
+
+.problem-table tr:hover {
+  background: #111827;
+}
+
+.pagination {
+  display: flex;
+  justify-content: center;
+  margin-top: 10px;
+  gap: 8px;
+}
+
+.pagination button {
+  padding: 6px 10px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #1f2937;
+  color: #f1f5f9;
+  cursor: pointer;
+}
+
+.pagination button.active {
+  background: #3b82f6;
+}

--- a/codespace/server/app.js
+++ b/codespace/server/app.js
@@ -13,6 +13,7 @@ const authMiddleware = require("./middleware/authMiddleware")
 const usersRoute = require("./routes/users")
 const resourcesRoute = require("./routes/resources");
 const topicsRoute = require("./routes/topics");
+const problemsRoute = require("./routes/problems");
 const rateLimit = require('express-rate-limit');
 
 const app = express();
@@ -43,6 +44,7 @@ app.use('/api/rooms', authMiddleware, roomsRoute)
 app.use('/api/users', usersRoute)
 app.use('/api/resources', resourcesRoute)
 app.use('/api/topics', topicsRoute)
+app.use('/api/problems', problemsRoute)
 app.use('/test',test)
 app.use('/submit',submit)
 

--- a/codespace/server/model/practiceProblemModel.js
+++ b/codespace/server/model/practiceProblemModel.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const practiceProblemSchema = new mongoose.Schema({
+  name: { type: String, required: true },
+  link: { type: String, required: true },
+  topic: { type: String, required: true },
+  subtopic: { type: String, required: true },
+  difficulty: { type: String, required: true }
+});
+
+module.exports = mongoose.model('PracticeProblem', practiceProblemSchema);

--- a/codespace/server/routes/problems.js
+++ b/codespace/server/routes/problems.js
@@ -1,0 +1,64 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const Problem = require('../model/practiceProblemModel');
+const Topic = require('../model/topicModel');
+
+const router = express.Router();
+const url = process.env.MONGODB_URI || 'mongodb://localhost:27017/graduation_project';
+
+mongoose.connect(url);
+
+router.get('/', async (req, res) => {
+  try {
+    const problems = await Problem.find();
+    res.json(problems);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to fetch problems' });
+  }
+});
+
+router.post('/', async (req, res) => {
+  try {
+    const { name, link, topic, subtopic, difficulty } = req.body;
+    const problem = new Problem({ name, link, topic, subtopic, difficulty });
+    await problem.save();
+
+    await Topic.updateOne(
+      { topic, subtopic },
+      { topic, subtopic },
+      { upsert: true }
+    );
+
+    res.status(201).json(problem);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to create problem' });
+  }
+});
+
+router.patch('/:id', async (req, res) => {
+  try {
+    const { name, link, topic, subtopic, difficulty } = req.body;
+    const update = {};
+    if (name !== undefined) update.name = name;
+    if (link !== undefined) update.link = link;
+    if (topic !== undefined) update.topic = topic;
+    if (subtopic !== undefined) update.subtopic = subtopic;
+    if (difficulty !== undefined) update.difficulty = difficulty;
+
+    const problem = await Problem.findByIdAndUpdate(req.params.id, update, { new: true });
+
+    if (problem && (update.topic !== undefined || update.subtopic !== undefined)) {
+      await Topic.updateOne(
+        { topic: problem.topic, subtopic: problem.subtopic },
+        { topic: problem.topic, subtopic: problem.subtopic },
+        { upsert: true }
+      );
+    }
+
+    res.json(problem);
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to update problem' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add Mongoose model and API routes for practice problems with topic and difficulty
- build problems page with sidebar forms and paginated table

## Testing
- `npm test` (server)
- `npm test` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68af68c30de483289b3b298992e44d9e