### PR TITLE
Fix compile output trim error

### DIFF
--- a/codespace/frontend/src/components/TextBox.js
+++ b/codespace/frontend/src/components/TextBox.js
@@ -35,13 +35,15 @@ export default function TextBox({socketRef,currentProbId}) {
 
 
     useEffect(() => {
-        console.log(`outputvalue changed to ${outputvalue}`);
-        // outputvalue = outputvalue.trim();
-        if(outputvalue==="Submitting.." || outputvalue===""){
+        // Ensure outputvalue is treated as a string before any string operations
+        const outputStr = String(outputvalue);
+        console.log(`outputvalue changed to ${outputStr}`);
+
+        if(outputStr === "Submitting.." || outputStr === ""){
             setColor('black');
         }
         else{
-            setColor(outputvalue.trim()==="Accepted" ? 'green' : 'red');
+            setColor(outputStr.trim()==="Accepted" ? 'green' : 'red');
         }
       }, [outputvalue]);
 
@@ -127,7 +129,7 @@ export default function TextBox({socketRef,currentProbId}) {
                 ></textarea>
             </div>
             <div className="output-area" style={{ color }}>
-                Output: {outputvalue}
+                Output: {String(outputvalue)}
             </div>
             {/* <div> Output Value: {outputvalue}</div> */}
         </div>


### PR DESCRIPTION
## Summary
- safeguard compile output handling so non-string values don't break trim logic
- display compile results reliably as strings

## Testing
- `cd codespace/frontend && npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68af70bbb5108328a1872997863d78d0