### PR TITLE
Improve problem table hover and website column

### DIFF
--- a/codespace/frontend/src/components/ProblemTable.js
+++ b/codespace/frontend/src/components/ProblemTable.js
@@ -12,6 +12,15 @@ function ProblemTable({ problems }) {
     window.open(url, '_blank', 'noopener,noreferrer');
   };
 
+  const getDomain = (link) => {
+    try {
+      const url = new URL(link.startsWith('http') ? link : `https://${link}`);
+      return url.hostname.replace(/^www\./, '');
+    } catch {
+      return '';
+    }
+  };
+
   const current = problems.slice(
     (currentPage - 1) * itemsPerPage,
     currentPage * itemsPerPage
@@ -25,7 +34,7 @@ function ProblemTable({ problems }) {
             <th>Name</th>
             <th>Topic</th>
             <th>Subtopic</th>
-            <th>Domain</th>
+            <th>Website</th>
             <th>Difficulty</th>
           </tr>
         </thead>
@@ -35,7 +44,7 @@ function ProblemTable({ problems }) {
               <td>{p.name}</td>
               <td>{p.topic}</td>
               <td>{p.subtopic}</td>
-              <td>{p.domain}</td>
+              <td>{p.domain || getDomain(p.link)}</td>
               <td>{p.difficulty}</td>
             </tr>
           ))}

--- a/codespace/frontend/src/styles/ProblemsPage.css
+++ b/codespace/frontend/src/styles/ProblemsPage.css
@@ -120,7 +120,7 @@
 }
 
 .problem-table tr:hover {
-  background: #111827;
+  background: #f3f4f6;
 }
 
 .pagination {


### PR DESCRIPTION
## Summary
- Show website in problems table by computing domain from link when missing
- Lighten problem row hover color for better readability

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68af727420a88328bd17a38ff2ae9575