### PR TITLE
Improve room page layout with fixed chat and split editor

### DIFF
--- a/codespace/frontend/src/components/TextBox.js
+++ b/codespace/frontend/src/components/TextBox.js
@@ -108,20 +108,19 @@ export default function TextBox({socketRef,currentProbId}) {
     
 
     return (
-    <div className="RHS">
+    <div className="editor-wrapper">
         <div className="code-area">
             <CodeMirror
                 value={textvalue}
-                height="60vh"
+                height="100%"
                 width="100%"
                 onChange={Handlechange}
                 extensions={[cpp()]}
             />
         </div>
-        <div className="input-output">
+        <div className="io-wrapper">
             <div className="input-area">
                 <textarea
-                    style={{ height: '5vh', resize: 'none' }}
                     id="input"
                     value={inputvalue}
                     onChange={Handlechangeinput}
@@ -131,12 +130,10 @@ export default function TextBox({socketRef,currentProbId}) {
             <div className="output-area" style={{ color }}>
                 Output: {String(outputvalue)}
             </div>
-            {/* <div> Output Value: {outputvalue}</div> */}
-        </div>
-        <div>
-            <button onClick={Handlecompile}>Compile</button>
-            <button onClick={Handlesubmit}>Submit</button>
-            {/* <div>{verdict}</div> */}
+            <div className="action-buttons">
+                <button onClick={Handlecompile}>Compile</button>
+                <button onClick={Handlesubmit}>Submit</button>
+            </div>
         </div>
     </div>
     )

--- a/codespace/frontend/src/styles/App.css
+++ b/codespace/frontend/src/styles/App.css
@@ -37,50 +37,53 @@ input {
   padding: 10px; /* Adjust as needed for spacing */
 }
 
-.RHS {
+.editor-wrapper {
   display: flex;
-  flex-direction: column;
+  height: 70vh;
+  gap: 1rem;
 }
 
 .code-area {
+  flex: 3;
   border: 1px solid #ddd;
   border-radius: 8px;
   overflow: hidden;
 }
 
-.input-output {
+.io-wrapper {
+  flex: 1;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  flex: 1;
-  margin-top: 1rem;
 }
 
-@media (min-width: 768px) {
-  .input-output {
-    flex-direction: row;
-  }
-}
-
-.input-area,
-.output-area {
+.input-area {
   flex: 1;
 }
 
 .input-area textarea {
   width: 100%;
+  height: 100%;
   padding: 0.5rem;
   border: 1px solid #ccc;
   border-radius: 8px;
   background: #fafafa;
+  resize: none;
 }
 
 .output-area {
+  flex: 1;
   padding: 0.5rem;
   border: 1px solid #ccc;
   border-radius: 8px;
   background: #ffffff;
-  min-height: 6vh;
+  overflow: auto;
+}
+
+.action-buttons {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
 }
 
 button {

--- a/codespace/frontend/src/styles/RoomPage.css
+++ b/codespace/frontend/src/styles/RoomPage.css
@@ -1,23 +1,26 @@
+
 .editor-background {
   position: relative;
-  min-height: 100vh;
+  height: 100vh;
   background: linear-gradient(135deg, #e3f2fd, #ffffff);
   display: flex;
-  flex-direction: column;
-  overflow-y: auto;
+  overflow: hidden;
   transition: background 0.5s ease;
 }
 
 .room-wrapper {
   display: flex;
+  flex: 1;
+  overflow: hidden;
 }
 
 .room-main {
+  flex: 1;
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  overflow: visible;
-  flex: 1;
+  overflow-y: auto;
+  padding-right: 1rem;
 }
 
 .problem-view,
@@ -26,14 +29,15 @@
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   padding: 1rem;
-  flex: 1;
-  overflow-y: auto;
+}
+
+.problem-view {
+  flex: 0 0 auto;
+  overflow: visible;
 }
 
 .editor-container {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+  flex: 0 0 auto;
 }
 
 .left-sidebar {


### PR DESCRIPTION
## Summary
- Keep room chat fixed on the left while main content scrolls
- Stack problem viewer above new split editor with side input/output
- Style editor for code on the left and IO/output on the right

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68af813718e88328a574c3945e6ea802