### PR TITLE
Make editor and IO sections scrollable

### DIFF
--- a/codespace/frontend/src/styles/App.css
+++ b/codespace/frontend/src/styles/App.css
@@ -59,6 +59,7 @@ input {
 
 .input-area {
   flex: 1;
+  overflow: auto;
 }
 
 .input-area textarea {
@@ -69,6 +70,7 @@ input {
   border-radius: 8px;
   background: #fafafa;
   resize: none;
+  overflow: auto;
 }
 
 .output-area {

--- a/codespace/frontend/src/styles/RoomPage.css
+++ b/codespace/frontend/src/styles/RoomPage.css
@@ -1,17 +1,18 @@
 
+
 .editor-background {
   position: relative;
-  height: 100vh;
+  min-height: 100vh;
   background: linear-gradient(135deg, #e3f2fd, #ffffff);
   display: flex;
-  overflow: hidden;
+  overflow-y: auto;
   transition: background 0.5s ease;
 }
 
 .room-wrapper {
   display: flex;
   flex: 1;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .room-main {
@@ -126,19 +127,9 @@
   transition: background 0.3s ease, transform 0.2s ease;
 }
 
+
 .leave-room-button:hover {
   background: #9a0007;
   transform: scale(1.03);
-}
-
-@media (min-width: 768px) {
-  .room-main {
-    flex-direction: row;
-  }
-
-  .problem-view,
-  .editor-container {
-    max-height: 90vh;
-  }
 }
 


### PR DESCRIPTION
## Summary
- Allow room page to scroll vertically and keep editor below the problem section
- Enable scrolling within code input and output panels

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68af839275908328a353bcf6fb4c9012