### PR TITLE
feat: add contests section with basic routes and pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,23 @@ files in their own directories when running without Docker.
 Default values for both Docker and manual setups are shown in the `.env.example`
 files.
 
+## Contests
+
+The project now includes a simple contests module.
+
+### API Endpoints
+
+- `GET /api/contests` – list upcoming and past contests
+- `GET /api/contests/:id` – fetch a specific contest
+- `POST /api/contests/:id/register` – register the current user
+- `POST /api/contests/:id/unregister` – unregister the user
+- `POST /api/contests` – create a contest *(admin only; authentication TBD)*
+
+### Frontend Pages
+
+- `/contests` – shows upcoming and past contests with registration buttons
+- `/contests/:id` – template page for a contest's problems, scoreboard and timer
+
 ## Migrating existing S3 data
 
 If you previously stored tests in S3, you can copy them locally using the

--- a/codespace/frontend/src/App.js
+++ b/codespace/frontend/src/App.js
@@ -5,6 +5,7 @@ import SignupPage from './pages/SignupPage';
 import { Route, Routes, Navigate } from 'react-router-dom';
 import Room from './components/Room';
 import ContestPage from './pages/ContestPage';
+import ContestDetailPage from './pages/ContestDetailPage';
 import RoomsPage from './pages/RoomsPage';
 import ProblemsPage from './pages/ProblemsPage';
 import ResourcesPage from './pages/ResourcesPage';
@@ -22,7 +23,8 @@ function App(){
         <Route path="/problems" element={<ProblemsPage />} />
         <Route path="/resources" element={<ResourcesPage />} />
         <Route path="/sections" element={<SectionsPage />} />
-        <Route path="/contest" element={<ContestPage />} />
+        <Route path="/contests" element={<ContestPage />} />
+        <Route path="/contests/:id" element={<ContestDetailPage />} />
         <Route path="/rooms" element={<RoomsPage />} />
         <Route path="/contact" element={<ContactPage />} />
         <Route path="/profile" element={<ProfilePage />} />

--- a/codespace/frontend/src/components/NavBar.js
+++ b/codespace/frontend/src/components/NavBar.js
@@ -47,7 +47,7 @@ function NavBar() {
         <li><Link to="/problems">Problems</Link></li>
         <li><Link to="/resources">Resources</Link></li>
         <li><Link to="/sections">Sections</Link></li>
-        <li><Link to="/contest">Contest</Link></li>
+        <li><Link to="/contests">Contests</Link></li>
         <li><Link to="/rooms">Rooms</Link></li>
         <li><Link to="/contact">Contact Us</Link></li>
         {!loggedIn && <li><Link to="/login">Login</Link></li>}

--- a/codespace/frontend/src/pages/ContestDetailPage.js
+++ b/codespace/frontend/src/pages/ContestDetailPage.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { Box, Typography } from '@mui/material';
+import NavBar from '../components/NavBar';
+
+function ContestDetailPage() {
+  const { id } = useParams();
+
+  return (
+    <>
+      <NavBar />
+      <Box sx={{ maxWidth: 800, mx: 'auto', mt: 4 }}>
+        <Typography variant="h4" gutterBottom>
+          Contest Details
+        </Typography>
+        <Typography variant="subtitle1" gutterBottom>
+          Contest ID: {id}
+        </Typography>
+        {/* TODO: Replace placeholders with real contest data */}
+        <Box sx={{ mt: 4 }}>
+          <Typography variant="h6">Problems</Typography>
+          <Box sx={{ height: 100, bgcolor: '#f5f5f5', mb: 3 }} />
+          <Typography variant="h6">Scoreboard</Typography>
+          <Box sx={{ height: 100, bgcolor: '#f5f5f5', mb: 3 }} />
+          <Typography variant="h6">Countdown Timer</Typography>
+          <Box sx={{ height: 40, bgcolor: '#f5f5f5', mb: 3 }} />
+          <Typography variant="h6">Registration Status</Typography>
+          <Box sx={{ height: 40, bgcolor: '#f5f5f5', mb: 3 }} />
+        </Box>
+      </Box>
+    </>
+  );
+}
+
+export default ContestDetailPage;

--- a/codespace/server/model/contestModel.js
+++ b/codespace/server/model/contestModel.js
@@ -4,6 +4,11 @@ const contestSchema = new mongoose.Schema({
   name: { type: String, required: true },
   startTime: { type: Date, required: true },
   duration: { type: Number, required: true },
+  status: {
+    type: String,
+    enum: ['upcoming', 'running', 'finished'],
+    default: 'upcoming'
+  },
   problems: [{ type: String }],
   participants: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }]
 });

--- a/codespace/server/routes/contests.js
+++ b/codespace/server/routes/contests.js
@@ -5,11 +5,18 @@ const Contest = require('../model/contestModel');
 const router = express.Router();
 const url = process.env.MONGODB_URI || 'mongodb://localhost:27017/graduation_project';
 
-mongoose.connect(url);
+// Reuse existing connection if available
+if (mongoose.connection.readyState === 0) {
+  mongoose.connect(url);
+}
 
 // Create a new contest (admin only - auth not implemented here)
+// TODO: add proper authentication and authorization
 router.post('/', async (req, res) => {
-  const { name, startTime, duration, problems } = req.body;
+  const { name, startTime, duration, problems = [] } = req.body;
+  if (!name || !startTime || !duration) {
+    return res.status(400).json({ message: 'Missing required fields' });
+  }
   try {
     const contest = new Contest({ name, startTime, duration, problems });
     await contest.save();
@@ -19,12 +26,26 @@ router.post('/', async (req, res) => {
   }
 });
 
-// List upcoming contests
+// List upcoming and past contests separately
 router.get('/', async (req, res) => {
   try {
     const now = new Date();
-    const contests = await Contest.find({ startTime: { $gte: now } }).sort({ startTime: 1 });
-    res.json(contests);
+    const upcoming = await Contest.find({ startTime: { $gte: now } }).sort({ startTime: 1 });
+    const past = await Contest.find({ startTime: { $lt: now } }).sort({ startTime: -1 });
+    res.json({ upcoming, past });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+// Get details of a single contest
+router.get('/:id', async (req, res) => {
+  try {
+    const contest = await Contest.findById(req.params.id);
+    if (!contest) {
+      return res.status(404).json({ message: 'Contest not found' });
+    }
+    res.json(contest);
   } catch (err) {
     res.status(500).json({ message: 'Server error' });
   }
@@ -33,17 +54,41 @@ router.get('/', async (req, res) => {
 // Register a user for a contest
 router.post('/:id/register', async (req, res) => {
   const { userId } = req.body;
+  if (!userId || !mongoose.Types.ObjectId.isValid(userId)) {
+    return res.status(400).json({ message: 'Invalid userId' });
+  }
   try {
     const contest = await Contest.findById(req.params.id);
     if (!contest) {
       return res.status(404).json({ message: 'Contest not found' });
     }
-    if (contest.participants.includes(userId)) {
+    if (contest.participants.some((id) => id.equals(userId))) {
       return res.status(400).json({ message: 'Already registered' });
     }
-    contest.participants.push(userId);
+    contest.participants.push(new mongoose.Types.ObjectId(userId));
     await contest.save();
     res.json({ message: 'Registered' });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+// Unregister a user from a contest
+router.post('/:id/unregister', async (req, res) => {
+  const { userId } = req.body;
+  if (!userId || !mongoose.Types.ObjectId.isValid(userId)) {
+    return res.status(400).json({ message: 'Invalid userId' });
+  }
+  try {
+    const contest = await Contest.findById(req.params.id);
+    if (!contest) {
+      return res.status(404).json({ message: 'Contest not found' });
+    }
+    contest.participants = contest.participants.filter(
+      (id) => !id.equals(userId)
+    );
+    await contest.save();
+    res.json({ message: 'Unregistered' });
   } catch (err) {
     res.status(500).json({ message: 'Server error' });
   }


### PR DESCRIPTION
## Summary
- add contest model status field and CRUD/registration routes
- create contests list page with tabs and registration, plus detail template
- document API and pages in README

## Testing
- `npm test` (server) *(fails: Missing script)*
- `CI=true npm test -- --watchAll=false --passWithNoTests` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68b04f92a5308328880a62a9b7236810