### PR TITLE
Add contest seeding script and empty contest messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ The project now includes a simple contests module.
 - `/contests` – shows upcoming and past contests with registration buttons
 - `/contests/:id` – template page for a contest's problems, scoreboard and timer
 
+### Seeding example contests
+
+With the server running, seed sample data by running:
+
+```
+node codespace/server/scripts/seedContests.js
+```
+
+This script POSTs one upcoming and one past contest to `/api/contests` and
+prints the counts returned by `GET /api/contests`.
+
 ## Migrating existing S3 data
 
 If you previously stored tests in S3, you can copy them locally using the

--- a/codespace/frontend/src/pages/ContestPage.js
+++ b/codespace/frontend/src/pages/ContestPage.js
@@ -97,14 +97,22 @@ function ContestPage() {
           <Tab label="Past" />
         </Tabs>
         <Box hidden={tab !== 0} sx={{ mt: 2 }}>
-          {upcoming.map((contest) => (
-            <ContestCard key={contest._id} contest={contest} onRegister={register} />
-          ))}
+          {upcoming.length > 0 ? (
+            upcoming.map((contest) => (
+              <ContestCard key={contest._id} contest={contest} onRegister={register} />
+            ))
+          ) : (
+            <Typography>No upcoming contests</Typography>
+          )}
         </Box>
         <Box hidden={tab !== 1} sx={{ mt: 2 }}>
-          {past.map((contest) => (
-            <ContestCard key={contest._id} contest={contest} />
-          ))}
+          {past.length > 0 ? (
+            past.map((contest) => (
+              <ContestCard key={contest._id} contest={contest} />
+            ))
+          ) : (
+            <Typography>No past contests</Typography>
+          )}
         </Box>
       </Box>
     </>

--- a/codespace/server/scripts/seedContests.js
+++ b/codespace/server/scripts/seedContests.js
@@ -1,0 +1,48 @@
+const fetch = require('node-fetch');
+const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:6909';
+
+async function seed() {
+  const contests = [
+    {
+      name: 'Seeded Upcoming Contest',
+      startTime: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      duration: 90,
+      problems: []
+    },
+    {
+      name: 'Seeded Past Contest',
+      startTime: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      duration: 60,
+      problems: []
+    }
+  ];
+
+  for (const contest of contests) {
+    try {
+      const res = await fetch(`${BACKEND_URL}/api/contests`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(contest)
+      });
+      const data = await res.json();
+      if (res.ok) {
+        console.log(`Created contest: ${data.name}`);
+      } else {
+        console.error(`Failed to create contest: ${data.message || res.statusText}`);
+      }
+    } catch (err) {
+      console.error('Error creating contest', err);
+    }
+  }
+
+  try {
+    const res = await fetch(`${BACKEND_URL}/api/contests`);
+    const data = await res.json();
+    console.log(`Upcoming contests: ${data.upcoming.length}`);
+    console.log(`Past contests: ${data.past.length}`);
+  } catch (err) {
+    console.error('Error fetching contests', err);
+  }
+}
+
+seed();


### PR DESCRIPTION
## Summary
- Show placeholder text when no upcoming or past contests exist
- Add a seeding script to create sample upcoming and past contests
- Document how to seed contests in the README

## Testing
- `npm test -- --watchAll=false` *(frontend: no tests found)*
- `npm test` *(server: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b0594c3bec8328993cbbefb2de938d