### PR TITLE
Implement categorized sections combining resources and problems

### DIFF
--- a/codespace/frontend/src/pages/SectionsPage.js
+++ b/codespace/frontend/src/pages/SectionsPage.js
@@ -1,13 +1,162 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
 import NavBar from '../components/NavBar';
+import BACKEND_URL from '../config';
+import '../styles/SectionsPage.css';
+
+const levels = ['Bronze', 'Silver', 'Gold'];
 
 function SectionsPage() {
+  const [level, setLevel] = useState('Bronze');
+  const [topics, setTopics] = useState({});
+  const [selectedTopic, setSelectedTopic] = useState(null);
+  const [selectedSubtopic, setSelectedSubtopic] = useState(null);
+  const [subtopicId, setSubtopicId] = useState(null);
+  const [resources, setResources] = useState([]);
+  const [problems, setProblems] = useState([]);
+  const [progress, setProgress] = useState('not started');
+
+  useEffect(() => {
+    const fetchTopics = async () => {
+      try {
+        const res = await axios.get(`${BACKEND_URL}/api/topics`, { params: { level } });
+        setTopics(res.data);
+      } catch (err) {
+        console.error('Failed to fetch topics', err);
+      }
+    };
+    fetchTopics();
+    setSelectedTopic(null);
+    setSelectedSubtopic(null);
+    setResources([]);
+    setProblems([]);
+  }, [level]);
+
+  const loadContent = async (topicName, sub) => {
+    try {
+      const resResources = await axios.get(`${BACKEND_URL}/api/resources`, {
+        params: { level, topic: topicName, subtopic: sub.subtopic },
+      });
+      setResources(resResources.data);
+
+      const resProblems = await axios.get(`${BACKEND_URL}/api/problems`, {
+        params: { level, topic: topicName, subtopic: sub.subtopic },
+      });
+      setProblems(resProblems.data);
+
+      setProgress(sub.progress || 'not started');
+      setSubtopicId(sub._id);
+      setSelectedTopic(topicName);
+      setSelectedSubtopic(sub.subtopic);
+    } catch (err) {
+      console.error('Failed to load content', err);
+    }
+  };
+
+  const updateProgress = async (value) => {
+    if (!subtopicId) return;
+    try {
+      await axios.patch(`${BACKEND_URL}/api/topics/${subtopicId}`, { progress: value });
+      setProgress(value);
+    } catch (err) {
+      console.error('Failed to update progress', err);
+    }
+  };
+
   return (
     <div>
       <NavBar />
-      <h1>Sections Page</h1>
+      <div className="sections-page">
+        <div className="sections-sidebar">
+          <div className="level-selector">
+            {levels.map((lvl) => (
+              <button
+                key={lvl}
+                className={lvl === level ? 'active' : ''}
+                onClick={() => setLevel(lvl)}
+              >
+                {lvl}
+              </button>
+            ))}
+          </div>
+          <div className="topics-list">
+            {Object.keys(topics).map((t) => (
+              <div key={t} className="topic-item">
+                <div className="topic-name">{t}</div>
+                <ul>
+                  {topics[t].map((sub) => (
+                    <li
+                      key={sub._id}
+                      className={
+                        selectedSubtopic === sub.subtopic && selectedTopic === t
+                          ? 'selected'
+                          : ''
+                      }
+                      onClick={() => loadContent(t, sub)}
+                    >
+                      {sub.subtopic}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="sections-content">
+          {selectedSubtopic ? (
+            <div>
+              <h2>
+                {selectedTopic} / {selectedSubtopic}
+              </h2>
+              <div className="content-block">
+                <h3>Resources</h3>
+                {resources.length ? (
+                  <ul>
+                    {resources.map((r) => (
+                      <li key={r._id}>
+                        <a href={r.link} target="_blank" rel="noreferrer">
+                          {r.name}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p>No resources available.</p>
+                )}
+              </div>
+              <div className="content-block">
+                <h3>Problems</h3>
+                {problems.length ? (
+                  <ul>
+                    {problems.map((p) => (
+                      <li key={p._id}>
+                        <a href={p.link} target="_blank" rel="noreferrer">
+                          {p.name}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p>No problems available.</p>
+                )}
+              </div>
+              <div className="progress-section">
+                <h3>Progress</h3>
+                <select value={progress} onChange={(e) => updateProgress(e.target.value)}>
+                  <option value="not started">Not Started</option>
+                  <option value="reading">Reading</option>
+                  <option value="finished">Finished</option>
+                </select>
+              </div>
+            </div>
+          ) : (
+            <p className="placeholder">Select a subtopic to view content</p>
+          )}
+        </div>
+      </div>
     </div>
   );
 }
 
 export default SectionsPage;
+

--- a/codespace/frontend/src/styles/SectionsPage.css
+++ b/codespace/frontend/src/styles/SectionsPage.css
@@ -1,0 +1,70 @@
+.sections-page {
+  display: flex;
+  height: calc(100vh - 60px);
+}
+
+.sections-sidebar {
+  width: 250px;
+  border-right: 1px solid #ccc;
+  overflow-y: auto;
+  padding: 1rem;
+}
+
+.level-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.level-selector button {
+  padding: 0.5rem;
+  border: none;
+  cursor: pointer;
+}
+
+.level-selector .active {
+  background-color: #1976d2;
+  color: #fff;
+}
+
+.topic-item {
+  margin-bottom: 1rem;
+}
+
+.topic-name {
+  font-weight: bold;
+}
+
+.topic-item ul {
+  list-style: none;
+  padding-left: 1rem;
+}
+
+.topic-item li {
+  cursor: pointer;
+  margin: 0.25rem 0;
+}
+
+.topic-item li.selected {
+  text-decoration: underline;
+}
+
+.sections-content {
+  flex: 1;
+  padding: 1rem;
+  overflow-y: auto;
+}
+
+.content-block {
+  margin-bottom: 1.5rem;
+}
+
+.progress-section {
+  margin-top: 2rem;
+}
+
+.placeholder {
+  color: #666;
+}
+

--- a/codespace/server/model/practiceProblemModel.js
+++ b/codespace/server/model/practiceProblemModel.js
@@ -3,6 +3,11 @@ const mongoose = require('mongoose');
 const practiceProblemSchema = new mongoose.Schema({
   name: { type: String, required: true },
   link: { type: String, required: true },
+  level: {
+    type: String,
+    enum: ['Bronze', 'Silver', 'Gold'],
+    required: true,
+  },
   topic: { type: String, required: true },
   subtopic: { type: String, required: true },
   difficulty: { type: String, required: true },

--- a/codespace/server/model/resourceModel.js
+++ b/codespace/server/model/resourceModel.js
@@ -3,6 +3,11 @@ const mongoose = require('mongoose');
 const resourceSchema = new mongoose.Schema({
   name: { type: String, required: true },
   link: { type: String, required: true },
+  level: {
+    type: String,
+    enum: ['Bronze', 'Silver', 'Gold'],
+    required: true,
+  },
   topic: { type: String, required: true },
   subtopic: { type: String, required: true },
   status: { type: String, default: 'Not Attempted' }

--- a/codespace/server/model/topicModel.js
+++ b/codespace/server/model/topicModel.js
@@ -1,11 +1,21 @@
 const mongoose = require('mongoose');
 
 const topicSchema = new mongoose.Schema({
+  level: {
+    type: String,
+    enum: ['Bronze', 'Silver', 'Gold'],
+    required: true,
+  },
   topic: { type: String, required: true },
-  subtopic: { type: String }
+  subtopic: { type: String, required: true },
+  progress: {
+    type: String,
+    enum: ['not started', 'reading', 'finished'],
+    default: 'not started',
+  },
 });
 
-// Ensure each topic/subtopic pair is unique
-topicSchema.index({ topic: 1, subtopic: 1 }, { unique: true });
+// Ensure each level/topic/subtopic combination is unique
+topicSchema.index({ level: 1, topic: 1, subtopic: 1 }, { unique: true });
 
 module.exports = mongoose.model('Topic', topicSchema);

--- a/codespace/server/routes/problems.js
+++ b/codespace/server/routes/problems.js
@@ -19,7 +19,12 @@ const getDomain = (link) => {
 
 router.get('/', async (req, res) => {
   try {
-    const problems = await Problem.find();
+    const { level, topic, subtopic } = req.query;
+    const filter = {};
+    if (level) filter.level = level;
+    if (topic) filter.topic = topic;
+    if (subtopic) filter.subtopic = subtopic;
+    const problems = await Problem.find(filter);
     const withDomains = problems.map((p) => {
       const obj = p.toObject();
       if (!obj.domain) {
@@ -35,14 +40,14 @@ router.get('/', async (req, res) => {
 
 router.post('/', async (req, res) => {
   try {
-    const { name, link, topic, subtopic, difficulty } = req.body;
+    const { name, link, level, topic, subtopic, difficulty } = req.body;
     const domain = getDomain(link);
-    const problem = new Problem({ name, link, topic, subtopic, difficulty, domain });
+    const problem = new Problem({ name, link, level, topic, subtopic, difficulty, domain });
     await problem.save();
 
     await Topic.updateOne(
-      { topic, subtopic },
-      { topic, subtopic },
+      { level, topic, subtopic },
+      { level, topic, subtopic },
       { upsert: true }
     );
 
@@ -54,23 +59,24 @@ router.post('/', async (req, res) => {
 
 router.patch('/:id', async (req, res) => {
   try {
-    const { name, link, topic, subtopic, difficulty } = req.body;
+    const { name, link, level, topic, subtopic, difficulty } = req.body;
     const update = {};
     if (name !== undefined) update.name = name;
     if (link !== undefined) {
       update.link = link;
       update.domain = getDomain(link);
     }
+    if (level !== undefined) update.level = level;
     if (topic !== undefined) update.topic = topic;
     if (subtopic !== undefined) update.subtopic = subtopic;
     if (difficulty !== undefined) update.difficulty = difficulty;
 
     const problem = await Problem.findByIdAndUpdate(req.params.id, update, { new: true });
 
-    if (problem && (update.topic !== undefined || update.subtopic !== undefined)) {
+    if (problem && (update.level !== undefined || update.topic !== undefined || update.subtopic !== undefined)) {
       await Topic.updateOne(
-        { topic: problem.topic, subtopic: problem.subtopic },
-        { topic: problem.topic, subtopic: problem.subtopic },
+        { level: problem.level, topic: problem.topic, subtopic: problem.subtopic },
+        { level: problem.level, topic: problem.topic, subtopic: problem.subtopic },
         { upsert: true }
       );
     }


### PR DESCRIPTION
## Summary
- categorize topics into Bronze, Silver, and Gold and track subtopic progress
- expose filtered resources and problems endpoints and allow progress updates
- build new sections page with sidebar navigation, combined resource/problem listings, and progress control

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68b0b93ee610832896d585a08d892de8