### PR TITLE
Refactor topic stages and sections navigation

### DIFF
--- a/codespace/frontend/src/components/ProblemSidebar.js
+++ b/codespace/frontend/src/components/ProblemSidebar.js
@@ -17,6 +17,8 @@ function ProblemSidebar({
   newSubtopic,
   setNewSubtopic,
   addSubtopic,
+  selectedStage,
+  handleStageChange,
   selectedTopic,
   handleTopicChange,
   selectedSubtopic,
@@ -48,17 +50,32 @@ function ProblemSidebar({
             required
           />
           <select
-            name="topic"
-            value={formData.topic}
+            name="stage"
+            value={formData.stage}
             onChange={handleFormChange}
             required
           >
-            <option value="">Select Topic</option>
-            {Object.keys(topics).map((topic) => (
-              <option key={topic} value={topic}>
-                {topic}
+            <option value="">Select Stage</option>
+            {['Bronze', 'Silver', 'Gold'].map((s) => (
+              <option key={s} value={s}>
+                {s}
               </option>
             ))}
+          </select>
+          <select
+            name="topic"
+            value={formData.topic}
+            onChange={handleFormChange}
+            disabled={!formData.stage}
+            required
+          >
+            <option value="">Select Topic</option>
+            {formData.stage &&
+              Object.keys(topics[formData.stage] || {}).map((topic) => (
+                <option key={topic} value={topic}>
+                  {topic}
+                </option>
+              ))}
           </select>
           <select
             name="subtopic"
@@ -68,8 +85,9 @@ function ProblemSidebar({
             required
           >
             <option value="">Select Subtopic</option>
-            {formData.topic &&
-              topics[formData.topic].map((sub) => (
+            {formData.stage &&
+              formData.topic &&
+              topics[formData.stage][formData.topic].map((sub) => (
                 <option key={sub} value={sub}>
                   {sub}
                 </option>
@@ -92,10 +110,22 @@ function ProblemSidebar({
       )}
       {showTopicForm && (
         <form className="add-topic-form" onSubmit={addTopic}>
+          <select
+            value={newTopic.stage}
+            onChange={(e) => setNewTopic((prev) => ({ ...prev, stage: e.target.value }))}
+            required
+          >
+            <option value="">Select Stage</option>
+            {['Bronze', 'Silver', 'Gold'].map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
           <input
             type="text"
-            value={newTopic}
-            onChange={(e) => setNewTopic(e.target.value)}
+            value={newTopic.name}
+            onChange={(e) => setNewTopic((prev) => ({ ...prev, name: e.target.value }))}
             placeholder="Topic Name"
             required
           />
@@ -105,16 +135,30 @@ function ProblemSidebar({
       {showSubtopicForm && (
         <form className="add-subtopic-form" onSubmit={addSubtopic}>
           <select
+            value={newSubtopic.stage}
+            onChange={(e) => setNewSubtopic((prev) => ({ ...prev, stage: e.target.value, topic: '' }))}
+            required
+          >
+            <option value="">Select Stage</option>
+            {['Bronze', 'Silver', 'Gold'].map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+          <select
             value={newSubtopic.topic}
             onChange={(e) => setNewSubtopic((prev) => ({ ...prev, topic: e.target.value }))}
+            disabled={!newSubtopic.stage}
             required
           >
             <option value="">Select Topic</option>
-            {Object.keys(topics).map((topic) => (
-              <option key={topic} value={topic}>
-                {topic}
-              </option>
-            ))}
+            {newSubtopic.stage &&
+              Object.keys(topics[newSubtopic.stage] || {}).map((topic) => (
+                <option key={topic} value={topic}>
+                  {topic}
+                </option>
+              ))}
           </select>
           <input
             type="text"
@@ -126,13 +170,22 @@ function ProblemSidebar({
           <button type="submit">Add</button>
         </form>
       )}
-      <select value={selectedTopic} onChange={handleTopicChange}>
-        <option value="">All Topics</option>
-        {Object.keys(topics).map((topic) => (
-          <option key={topic} value={topic}>
-            {topic}
+      <select value={selectedStage} onChange={handleStageChange}>
+        <option value="">All Stages</option>
+        {['Bronze', 'Silver', 'Gold'].map((s) => (
+          <option key={s} value={s}>
+            {s}
           </option>
         ))}
+      </select>
+      <select value={selectedTopic} onChange={handleTopicChange} disabled={!selectedStage}>
+        <option value="">All Topics</option>
+        {selectedStage &&
+          Object.keys(topics[selectedStage] || {}).map((topic) => (
+            <option key={topic} value={topic}>
+              {topic}
+            </option>
+          ))}
       </select>
       <select
         value={selectedSubtopic}
@@ -140,8 +193,9 @@ function ProblemSidebar({
         disabled={!selectedTopic}
       >
         <option value="">All Subtopics</option>
-        {selectedTopic &&
-          topics[selectedTopic].map((sub) => (
+        {selectedStage &&
+          selectedTopic &&
+          topics[selectedStage][selectedTopic].map((sub) => (
             <option key={sub} value={sub}>
               {sub}
             </option>

--- a/codespace/frontend/src/components/ResourcesSidebar.js
+++ b/codespace/frontend/src/components/ResourcesSidebar.js
@@ -17,6 +17,8 @@ function ResourcesSidebar({
   newSubtopic,
   setNewSubtopic,
   addSubtopic,
+  selectedStage,
+  handleStageChange,
   selectedTopic,
   handleTopicChange,
   selectedSubtopic,
@@ -48,17 +50,32 @@ function ResourcesSidebar({
             required
           />
           <select
-            name="topic"
-            value={formData.topic}
+            name="stage"
+            value={formData.stage}
             onChange={handleFormChange}
             required
           >
-            <option value="">Select Topic</option>
-            {Object.keys(topics).map((topic) => (
-              <option key={topic} value={topic}>
-                {topic}
+            <option value="">Select Stage</option>
+            {['Bronze', 'Silver', 'Gold'].map((s) => (
+              <option key={s} value={s}>
+                {s}
               </option>
             ))}
+          </select>
+          <select
+            name="topic"
+            value={formData.topic}
+            onChange={handleFormChange}
+            disabled={!formData.stage}
+            required
+          >
+            <option value="">Select Topic</option>
+            {formData.stage &&
+              Object.keys(topics[formData.stage] || {}).map((topic) => (
+                <option key={topic} value={topic}>
+                  {topic}
+                </option>
+              ))}
           </select>
           <select
             name="subtopic"
@@ -68,8 +85,9 @@ function ResourcesSidebar({
             required
           >
             <option value="">Select Subtopic</option>
-            {formData.topic &&
-              topics[formData.topic].map((sub) => (
+            {formData.stage &&
+              formData.topic &&
+              topics[formData.stage][formData.topic].map((sub) => (
                 <option key={sub} value={sub}>
                   {sub}
                 </option>
@@ -80,10 +98,22 @@ function ResourcesSidebar({
       )}
       {showTopicForm && (
         <form className="add-topic-form" onSubmit={addTopic}>
+          <select
+            value={newTopic.stage}
+            onChange={(e) => setNewTopic((prev) => ({ ...prev, stage: e.target.value }))}
+            required
+          >
+            <option value="">Select Stage</option>
+            {['Bronze', 'Silver', 'Gold'].map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
           <input
             type="text"
-            value={newTopic}
-            onChange={(e) => setNewTopic(e.target.value)}
+            value={newTopic.name}
+            onChange={(e) => setNewTopic((prev) => ({ ...prev, name: e.target.value }))}
             placeholder="Topic Name"
             required
           />
@@ -93,16 +123,30 @@ function ResourcesSidebar({
       {showSubtopicForm && (
         <form className="add-subtopic-form" onSubmit={addSubtopic}>
           <select
+            value={newSubtopic.stage}
+            onChange={(e) => setNewSubtopic((prev) => ({ ...prev, stage: e.target.value, topic: '' }))}
+            required
+          >
+            <option value="">Select Stage</option>
+            {['Bronze', 'Silver', 'Gold'].map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
+          <select
             value={newSubtopic.topic}
             onChange={(e) => setNewSubtopic((prev) => ({ ...prev, topic: e.target.value }))}
+            disabled={!newSubtopic.stage}
             required
           >
             <option value="">Select Topic</option>
-            {Object.keys(topics).map((topic) => (
-              <option key={topic} value={topic}>
-                {topic}
-              </option>
-            ))}
+            {newSubtopic.stage &&
+              Object.keys(topics[newSubtopic.stage] || {}).map((topic) => (
+                <option key={topic} value={topic}>
+                  {topic}
+                </option>
+              ))}
           </select>
           <input
             type="text"
@@ -114,13 +158,22 @@ function ResourcesSidebar({
           <button type="submit">Add</button>
         </form>
       )}
-      <select value={selectedTopic} onChange={handleTopicChange}>
-        <option value="">All Topics</option>
-        {Object.keys(topics).map((topic) => (
-          <option key={topic} value={topic}>
-            {topic}
+      <select value={selectedStage} onChange={handleStageChange}>
+        <option value="">All Stages</option>
+        {['Bronze', 'Silver', 'Gold'].map((s) => (
+          <option key={s} value={s}>
+            {s}
           </option>
         ))}
+      </select>
+      <select value={selectedTopic} onChange={handleTopicChange} disabled={!selectedStage}>
+        <option value="">All Topics</option>
+        {selectedStage &&
+          Object.keys(topics[selectedStage] || {}).map((topic) => (
+            <option key={topic} value={topic}>
+              {topic}
+            </option>
+          ))}
       </select>
       <select
         value={selectedSubtopic}
@@ -128,8 +181,9 @@ function ResourcesSidebar({
         disabled={!selectedTopic}
       >
         <option value="">All Subtopics</option>
-        {selectedTopic &&
-          topics[selectedTopic].map((sub) => (
+        {selectedStage &&
+          selectedTopic &&
+          topics[selectedStage][selectedTopic].map((sub) => (
             <option key={sub} value={sub}>
               {sub}
             </option>

--- a/codespace/frontend/src/styles/SectionsPage.css
+++ b/codespace/frontend/src/styles/SectionsPage.css
@@ -10,20 +10,21 @@
   padding: 1rem;
 }
 
-.level-selector {
+.stages-list {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  margin-bottom: 1rem;
 }
 
-.level-selector button {
+.stage-item button {
   padding: 0.5rem;
   border: none;
+  width: 100%;
+  text-align: left;
   cursor: pointer;
 }
 
-.level-selector .active {
+.stage-item button.active {
   background-color: #1976d2;
   color: #fff;
 }

--- a/codespace/server/model/practiceProblemModel.js
+++ b/codespace/server/model/practiceProblemModel.js
@@ -3,7 +3,7 @@ const mongoose = require('mongoose');
 const practiceProblemSchema = new mongoose.Schema({
   name: { type: String, required: true },
   link: { type: String, required: true },
-  level: {
+  stage: {
     type: String,
     enum: ['Bronze', 'Silver', 'Gold'],
     required: true,

--- a/codespace/server/model/resourceModel.js
+++ b/codespace/server/model/resourceModel.js
@@ -3,7 +3,7 @@ const mongoose = require('mongoose');
 const resourceSchema = new mongoose.Schema({
   name: { type: String, required: true },
   link: { type: String, required: true },
-  level: {
+  stage: {
     type: String,
     enum: ['Bronze', 'Silver', 'Gold'],
     required: true,

--- a/codespace/server/model/topicModel.js
+++ b/codespace/server/model/topicModel.js
@@ -1,7 +1,7 @@
 const mongoose = require('mongoose');
 
 const topicSchema = new mongoose.Schema({
-  level: {
+  stage: {
     type: String,
     enum: ['Bronze', 'Silver', 'Gold'],
     required: true,
@@ -15,7 +15,7 @@ const topicSchema = new mongoose.Schema({
   },
 });
 
-// Ensure each level/topic/subtopic combination is unique
-topicSchema.index({ level: 1, topic: 1, subtopic: 1 }, { unique: true });
+// Ensure each stage/topic/subtopic combination is unique
+topicSchema.index({ stage: 1, topic: 1, subtopic: 1 }, { unique: true });
 
 module.exports = mongoose.model('Topic', topicSchema);

--- a/codespace/server/routes/problems.js
+++ b/codespace/server/routes/problems.js
@@ -19,9 +19,9 @@ const getDomain = (link) => {
 
 router.get('/', async (req, res) => {
   try {
-    const { level, topic, subtopic } = req.query;
+    const { stage, topic, subtopic } = req.query;
     const filter = {};
-    if (level) filter.level = level;
+    if (stage) filter.stage = stage;
     if (topic) filter.topic = topic;
     if (subtopic) filter.subtopic = subtopic;
     const problems = await Problem.find(filter);
@@ -40,14 +40,14 @@ router.get('/', async (req, res) => {
 
 router.post('/', async (req, res) => {
   try {
-    const { name, link, level, topic, subtopic, difficulty } = req.body;
+    const { name, link, stage, topic, subtopic, difficulty } = req.body;
     const domain = getDomain(link);
-    const problem = new Problem({ name, link, level, topic, subtopic, difficulty, domain });
+    const problem = new Problem({ name, link, stage, topic, subtopic, difficulty, domain });
     await problem.save();
 
     await Topic.updateOne(
-      { level, topic, subtopic },
-      { level, topic, subtopic },
+      { stage, topic, subtopic },
+      { stage, topic, subtopic },
       { upsert: true }
     );
 
@@ -59,24 +59,24 @@ router.post('/', async (req, res) => {
 
 router.patch('/:id', async (req, res) => {
   try {
-    const { name, link, level, topic, subtopic, difficulty } = req.body;
+    const { name, link, stage, topic, subtopic, difficulty } = req.body;
     const update = {};
     if (name !== undefined) update.name = name;
     if (link !== undefined) {
       update.link = link;
       update.domain = getDomain(link);
     }
-    if (level !== undefined) update.level = level;
+    if (stage !== undefined) update.stage = stage;
     if (topic !== undefined) update.topic = topic;
     if (subtopic !== undefined) update.subtopic = subtopic;
     if (difficulty !== undefined) update.difficulty = difficulty;
 
     const problem = await Problem.findByIdAndUpdate(req.params.id, update, { new: true });
 
-    if (problem && (update.level !== undefined || update.topic !== undefined || update.subtopic !== undefined)) {
+    if (problem && (update.stage !== undefined || update.topic !== undefined || update.subtopic !== undefined)) {
       await Topic.updateOne(
-        { level: problem.level, topic: problem.topic, subtopic: problem.subtopic },
-        { level: problem.level, topic: problem.topic, subtopic: problem.subtopic },
+        { stage: problem.stage, topic: problem.topic, subtopic: problem.subtopic },
+        { stage: problem.stage, topic: problem.topic, subtopic: problem.subtopic },
         { upsert: true }
       );
     }

--- a/codespace/server/routes/resources.js
+++ b/codespace/server/routes/resources.js
@@ -10,9 +10,9 @@ mongoose.connect(url);
 
 router.get('/', async (req, res) => {
   try {
-    const { level, topic, subtopic } = req.query;
+    const { stage, topic, subtopic } = req.query;
     const filter = {};
-    if (level) filter.level = level;
+    if (stage) filter.stage = stage;
     if (topic) filter.topic = topic;
     if (subtopic) filter.subtopic = subtopic;
     const resources = await Resource.find(filter);
@@ -24,13 +24,13 @@ router.get('/', async (req, res) => {
 
 router.post('/', async (req, res) => {
   try {
-    const { name, link, level, topic, subtopic } = req.body;
-    const resource = new Resource({ name, link, level, topic, subtopic });
+    const { name, link, stage, topic, subtopic } = req.body;
+    const resource = new Resource({ name, link, stage, topic, subtopic });
     await resource.save();
 
     await Topic.updateOne(
-      { level, topic, subtopic },
-      { level, topic, subtopic },
+      { stage, topic, subtopic },
+      { stage, topic, subtopic },
       { upsert: true }
     );
 
@@ -42,21 +42,21 @@ router.post('/', async (req, res) => {
 
 router.patch('/:id', async (req, res) => {
   try {
-    const { status, name, link, level, topic, subtopic } = req.body;
+    const { status, name, link, stage, topic, subtopic } = req.body;
     const update = {};
     if (status !== undefined) update.status = status;
     if (name !== undefined) update.name = name;
     if (link !== undefined) update.link = link;
-    if (level !== undefined) update.level = level;
+    if (stage !== undefined) update.stage = stage;
     if (topic !== undefined) update.topic = topic;
     if (subtopic !== undefined) update.subtopic = subtopic;
 
     const resource = await Resource.findByIdAndUpdate(req.params.id, update, { new: true });
 
-    if (resource && (update.level !== undefined || update.topic !== undefined || update.subtopic !== undefined)) {
+    if (resource && (update.stage !== undefined || update.topic !== undefined || update.subtopic !== undefined)) {
       await Topic.updateOne(
-        { level: resource.level, topic: resource.topic, subtopic: resource.subtopic },
-        { level: resource.level, topic: resource.topic, subtopic: resource.subtopic },
+        { stage: resource.stage, topic: resource.topic, subtopic: resource.subtopic },
+        { stage: resource.stage, topic: resource.topic, subtopic: resource.subtopic },
         { upsert: true }
       );
     }

--- a/codespace/server/routes/topics.js
+++ b/codespace/server/routes/topics.js
@@ -9,12 +9,12 @@ mongoose.connect(url);
 
 router.get('/', async (req, res) => {
   try {
-    const { level } = req.query;
-    const filter = level ? { level } : {};
+    const { stage } = req.query;
+    const filter = stage ? { stage } : {};
     const topics = await Topic.find(filter).lean();
-    const formatted = topics.reduce((acc, { _id, level, topic, subtopic, progress }) => {
+    const formatted = topics.reduce((acc, { _id, stage, topic, subtopic, progress }) => {
       if (!acc[topic]) acc[topic] = [];
-      acc[topic].push({ _id, subtopic, progress, level });
+      acc[topic].push({ _id, subtopic, progress, stage });
       return acc;
     }, {});
     res.json(formatted);
@@ -25,13 +25,13 @@ router.get('/', async (req, res) => {
 
 router.post('/', async (req, res) => {
   try {
-    const { level, topic, subtopic } = req.body;
+    const { stage, topic, subtopic } = req.body;
     await Topic.updateOne(
-      { level, topic, subtopic },
-      { level, topic, subtopic },
+      { stage, topic, subtopic },
+      { stage, topic, subtopic },
       { upsert: true }
     );
-    res.status(201).json({ level, topic, subtopic });
+    res.status(201).json({ stage, topic, subtopic });
   } catch (err) {
     res.status(500).json({ error: 'Failed to save topic' });
   }
@@ -39,10 +39,10 @@ router.post('/', async (req, res) => {
 
 router.patch('/:id', async (req, res) => {
   try {
-    const { progress, level, topic, subtopic } = req.body;
+    const { progress, stage, topic, subtopic } = req.body;
     const update = {};
     if (progress !== undefined) update.progress = progress;
-    if (level !== undefined) update.level = level;
+    if (stage !== undefined) update.stage = stage;
     if (topic !== undefined) update.topic = topic;
     if (subtopic !== undefined) update.subtopic = subtopic;
     const topicDoc = await Topic.findByIdAndUpdate(req.params.id, update, { new: true });


### PR DESCRIPTION
## Summary
- Replace `level` with `stage` across models and routes
- Show Bronze, Silver and Gold stages with nested topics on the Sections page
- Allow selecting a stage when adding resources or problems

## Testing
- `CI=true npm test --silent` (frontend) *(no tests found)*
- `npm test` (server) *(missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b0bb9403508328b9f2d60ff0a0a498