### PR TITLE
Revamp stages list on sections page

### DIFF
--- a/codespace/frontend/src/pages/SectionsPage.js
+++ b/codespace/frontend/src/pages/SectionsPage.js
@@ -74,15 +74,20 @@ function SectionsPage() {
       <NavBar />
       <div className="sections-page">
         <div className="sections-sidebar">
-          <div className="stages-list">
+          <ul className="stages-list">
             {stages.map((stage) => (
-              <div key={stage} className="stage-item">
-                <button
-                  className={openStage === stage ? 'active' : ''}
-                  onClick={() => setOpenStage(openStage === stage ? null : stage)}
+              <li
+                key={stage}
+                className={`stage-item ${openStage === stage ? 'active' : ''}`}
+              >
+                <div
+                  className="stage-title"
+                  onClick={() =>
+                    setOpenStage(openStage === stage ? null : stage)
+                  }
                 >
                   {stage}
-                </button>
+                </div>
                 {openStage === stage && (
                   <div className="topics-list">
                     {Object.keys(topics[stage] || {}).map((t) => (
@@ -109,9 +114,9 @@ function SectionsPage() {
                     ))}
                   </div>
                 )}
-              </div>
+              </li>
             ))}
-          </div>
+          </ul>
         </div>
         <div className="sections-content">
           {selectedSubtopic ? (

--- a/codespace/frontend/src/styles/SectionsPage.css
+++ b/codespace/frontend/src/styles/SectionsPage.css
@@ -11,22 +11,32 @@
 }
 
 .stages-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
 }
 
-.stage-item button {
+.stage-item {
   padding: 0.5rem;
-  border: none;
-  width: 100%;
-  text-align: left;
+  border-radius: 4px;
   cursor: pointer;
+  transition: background-color 0.3s;
 }
 
-.stage-item button.active {
+.stage-item:hover {
+  background-color: #f0f0f0;
+}
+
+.stage-item.active {
   background-color: #1976d2;
   color: #fff;
+}
+
+.stage-title {
+  font-weight: bold;
 }
 
 .topic-item {


### PR DESCRIPTION
## Summary
- Replace stages buttons with list items on the Sections page
- Enhance stages styling for better hover and active states

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c03c82b88328942617db9225fbff