### PR TITLE
feat: switch stages to dropdown

### DIFF
--- a/codespace/frontend/src/pages/SectionsPage.js
+++ b/codespace/frontend/src/pages/SectionsPage.js
@@ -3,12 +3,13 @@ import axios from 'axios';
 import NavBar from '../components/NavBar';
 import BACKEND_URL from '../config';
 import '../styles/SectionsPage.css';
+import { FormControl, InputLabel, MenuItem, Select } from '@mui/material';
 
 const stages = ['Bronze', 'Silver', 'Gold'];
 
 function SectionsPage() {
   const [topics, setTopics] = useState({});
-  const [openStage, setOpenStage] = useState(null);
+  const [stageFilter, setStageFilter] = useState(stages[0]);
   const [selectedStage, setSelectedStage] = useState(null);
   const [selectedTopic, setSelectedTopic] = useState(null);
   const [selectedSubtopic, setSelectedSubtopic] = useState(null);
@@ -74,49 +75,49 @@ function SectionsPage() {
       <NavBar />
       <div className="sections-page">
         <div className="sections-sidebar">
-          <ul className="stages-list">
-            {stages.map((stage) => (
-              <li
-                key={stage}
-                className={`stage-item ${openStage === stage ? 'active' : ''}`}
-              >
-                <div
-                  className="stage-title"
-                  onClick={() =>
-                    setOpenStage(openStage === stage ? null : stage)
-                  }
-                >
+          <FormControl fullWidth className="stage-select">
+            <InputLabel id="stage-select-label">Stage</InputLabel>
+            <Select
+              labelId="stage-select-label"
+              value={stageFilter}
+              label="Stage"
+              onChange={(e) => {
+                setStageFilter(e.target.value);
+                setSelectedTopic(null);
+                setSelectedSubtopic(null);
+              }}
+            >
+              {stages.map((stage) => (
+                <MenuItem key={stage} value={stage}>
                   {stage}
-                </div>
-                {openStage === stage && (
-                  <div className="topics-list">
-                    {Object.keys(topics[stage] || {}).map((t) => (
-                      <div key={t} className="topic-item">
-                        <div className="topic-name">{t}</div>
-                        <ul>
-                          {topics[stage][t].map((sub) => (
-                            <li
-                              key={sub._id}
-                              className={
-                                selectedStage === stage &&
-                                selectedTopic === t &&
-                                selectedSubtopic === sub.subtopic
-                                  ? 'selected'
-                                  : ''
-                              }
-                              onClick={() => loadContent(stage, t, sub)}
-                            >
-                              {sub.subtopic}
-                            </li>
-                          ))}
-                        </ul>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </li>
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <div className="topics-list">
+            {Object.keys(topics[stageFilter] || {}).map((t) => (
+              <div key={t} className="topic-item">
+                <div className="topic-name">{t}</div>
+                <ul>
+                  {topics[stageFilter][t].map((sub) => (
+                    <li
+                      key={sub._id}
+                      className={
+                        selectedStage === stageFilter &&
+                        selectedTopic === t &&
+                        selectedSubtopic === sub.subtopic
+                          ? 'selected'
+                          : ''
+                      }
+                      onClick={() => loadContent(stageFilter, t, sub)}
+                    >
+                      {sub.subtopic}
+                    </li>
+                  ))}
+                </ul>
+              </div>
             ))}
-          </ul>
+          </div>
         </div>
         <div className="sections-content">
           {selectedSubtopic ? (

--- a/codespace/frontend/src/styles/SectionsPage.css
+++ b/codespace/frontend/src/styles/SectionsPage.css
@@ -10,33 +10,8 @@
   padding: 1rem;
 }
 
-.stages-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-.stage-item {
-  padding: 0.5rem;
-  border-radius: 4px;
-  cursor: pointer;
-  transition: background-color 0.3s;
-}
-
-.stage-item:hover {
-  background-color: #f0f0f0;
-}
-
-.stage-item.active {
-  background-color: #1976d2;
-  color: #fff;
-}
-
-.stage-title {
-  font-weight: bold;
+.stage-select {
+  margin-bottom: 1rem;
 }
 
 .topic-item {


### PR DESCRIPTION
## Summary
- replace stage buttons with a Material UI Select dropdown on the Sections page
- clean up sidebar CSS and add spacing for the new dropdown

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b0c16818d08328a2bc73675c790d12