### PR TITLE
Add problem status and table layout for sections page

### DIFF
--- a/codespace/frontend/src/pages/SectionsPage.js
+++ b/codespace/frontend/src/pages/SectionsPage.js
@@ -125,37 +125,53 @@ function SectionsPage() {
               <h2>
                 {selectedStage} / {selectedTopic} / {selectedSubtopic}
               </h2>
-              <div className="content-block">
-                <h3>Resources</h3>
-                {resources.length ? (
-                  <ul>
-                    {resources.map((r) => (
-                      <li key={r._id}>
-                        <a href={r.link} target="_blank" rel="noreferrer">
-                          {r.name}
-                        </a>
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <p>No resources available.</p>
-                )}
-              </div>
-              <div className="content-block">
-                <h3>Problems</h3>
-                {problems.length ? (
-                  <ul>
-                    {problems.map((p) => (
-                      <li key={p._id}>
-                        <a href={p.link} target="_blank" rel="noreferrer">
-                          {p.name}
-                        </a>
-                      </li>
-                    ))}
-                  </ul>
-                ) : (
-                  <p>No problems available.</p>
-                )}
+              <div className="content-block content-split">
+                <div className="resources-side">
+                  <h3>Resources</h3>
+                  {resources.length ? (
+                    <ul>
+                      {resources.map((r) => (
+                        <li key={r._id}>
+                          <a href={r.link} target="_blank" rel="noreferrer">
+                            {r.name}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p>No resources available.</p>
+                  )}
+                </div>
+                <div className="problems-side">
+                  <h3>Problems</h3>
+                  {problems.length ? (
+                    <table className="problems-table">
+                      <thead>
+                        <tr>
+                          <th>Status</th>
+                          <th>Source Problem</th>
+                          <th>Name</th>
+                          <th>Difficulty</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {problems.map((p) => (
+                          <tr
+                            key={p._id}
+                            onClick={() => window.open(p.link, '_blank', 'noopener,noreferrer')}
+                          >
+                            <td>{p.status || 'Not Attempted'}</td>
+                            <td>{p.domain}</td>
+                            <td>{p.name}</td>
+                            <td>{p.difficulty}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  ) : (
+                    <p>No problems available.</p>
+                  )}
+                </div>
               </div>
               <div className="progress-section">
                 <h3>Progress</h3>

--- a/codespace/frontend/src/styles/SectionsPage.css
+++ b/codespace/frontend/src/styles/SectionsPage.css
@@ -46,6 +46,33 @@
   margin-bottom: 1.5rem;
 }
 
+.content-split {
+  display: flex;
+  gap: 2rem;
+}
+
+.resources-side,
+.problems-side {
+  flex: 1;
+}
+
+.problems-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.problems-table th,
+.problems-table td {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.problems-table tr:hover {
+  background-color: #f5f5f5;
+  cursor: pointer;
+}
+
 .progress-section {
   margin-top: 2rem;
 }

--- a/codespace/server/model/practiceProblemModel.js
+++ b/codespace/server/model/practiceProblemModel.js
@@ -11,7 +11,8 @@ const practiceProblemSchema = new mongoose.Schema({
   topic: { type: String, required: true },
   subtopic: { type: String, required: true },
   difficulty: { type: String, required: true },
-  domain: { type: String, required: true }
+  domain: { type: String, required: true },
+  status: { type: String, default: 'Not Attempted' }
 });
 
 module.exports = mongoose.model('PracticeProblem', practiceProblemSchema);

--- a/codespace/server/routes/problems.js
+++ b/codespace/server/routes/problems.js
@@ -40,9 +40,9 @@ router.get('/', async (req, res) => {
 
 router.post('/', async (req, res) => {
   try {
-    const { name, link, stage, topic, subtopic, difficulty } = req.body;
+    const { name, link, stage, topic, subtopic, difficulty, status } = req.body;
     const domain = getDomain(link);
-    const problem = new Problem({ name, link, stage, topic, subtopic, difficulty, domain });
+    const problem = new Problem({ name, link, stage, topic, subtopic, difficulty, domain, status });
     await problem.save();
 
     await Topic.updateOne(
@@ -59,7 +59,7 @@ router.post('/', async (req, res) => {
 
 router.patch('/:id', async (req, res) => {
   try {
-    const { name, link, stage, topic, subtopic, difficulty } = req.body;
+    const { name, link, stage, topic, subtopic, difficulty, status } = req.body;
     const update = {};
     if (name !== undefined) update.name = name;
     if (link !== undefined) {
@@ -70,6 +70,7 @@ router.patch('/:id', async (req, res) => {
     if (topic !== undefined) update.topic = topic;
     if (subtopic !== undefined) update.subtopic = subtopic;
     if (difficulty !== undefined) update.difficulty = difficulty;
+    if (status !== undefined) update.status = status;
 
     const problem = await Problem.findByIdAndUpdate(req.params.id, update, { new: true });
 


### PR DESCRIPTION
## Summary
- include status on practice problems server-side and expose via API
- show problems in a clickable table on Sections page
- style new table and layout alongside resources

## Testing
- `npm test` (server) *(fails: Missing script: "test")*
- `npm test -- --watchAll=false` (frontend) *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c3c0691c8328a693c8e3aff12aad