### PR TITLE
Add resource table and improve section layout

### DIFF
--- a/codespace/frontend/src/pages/SectionsPage.js
+++ b/codespace/frontend/src/pages/SectionsPage.js
@@ -70,6 +70,14 @@ function SectionsPage() {
     }
   };
 
+  const openLink = (link) => {
+    const url =
+      link.startsWith('http://') || link.startsWith('https://')
+        ? link
+        : `https://${link}`;
+    window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
   return (
     <div>
       <NavBar />
@@ -129,15 +137,25 @@ function SectionsPage() {
                 <div className="resources-side">
                   <h3>Resources</h3>
                   {resources.length ? (
-                    <ul>
-                      {resources.map((r) => (
-                        <li key={r._id}>
-                          <a href={r.link} target="_blank" rel="noreferrer">
-                            {r.name}
-                          </a>
-                        </li>
-                      ))}
-                    </ul>
+                    <table className="resources-table">
+                      <thead>
+                        <tr>
+                          <th>Name</th>
+                          <th>Status</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {resources.map((r) => (
+                          <tr
+                            key={r._id}
+                            onClick={() => openLink(r.link)}
+                          >
+                            <td>{r.name}</td>
+                            <td>{r.status || 'Not Attempted'}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
                   ) : (
                     <p>No resources available.</p>
                   )}
@@ -158,7 +176,7 @@ function SectionsPage() {
                         {problems.map((p) => (
                           <tr
                             key={p._id}
-                            onClick={() => window.open(p.link, '_blank', 'noopener,noreferrer')}
+                            onClick={() => openLink(p.link)}
                           >
                             <td>{p.status || 'Not Attempted'}</td>
                             <td>{p.domain}</td>
@@ -175,11 +193,19 @@ function SectionsPage() {
               </div>
               <div className="progress-section">
                 <h3>Progress</h3>
-                <select value={progress} onChange={(e) => updateProgress(e.target.value)}>
-                  <option value="not started">Not Started</option>
-                  <option value="reading">Reading</option>
-                  <option value="finished">Finished</option>
-                </select>
+                <FormControl className="progress-select">
+                  <InputLabel id="progress-select-label">Progress</InputLabel>
+                  <Select
+                    labelId="progress-select-label"
+                    value={progress}
+                    label="Progress"
+                    onChange={(e) => updateProgress(e.target.value)}
+                  >
+                    <MenuItem value="not started">Not Started</MenuItem>
+                    <MenuItem value="reading">Reading</MenuItem>
+                    <MenuItem value="finished">Finished</MenuItem>
+                  </Select>
+                </FormControl>
               </div>
             </div>
           ) : (

--- a/codespace/frontend/src/styles/SectionsPage.css
+++ b/codespace/frontend/src/styles/SectionsPage.css
@@ -36,10 +36,18 @@
   text-decoration: underline;
 }
 
+
 .sections-content {
   flex: 1;
   padding: 1rem;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.sections-content > div {
+  width: 100%;
 }
 
 .content-block {
@@ -54,27 +62,42 @@
 .resources-side,
 .problems-side {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
-.problems-table {
+.problems-table,
+.resources-table {
   width: 100%;
   border-collapse: collapse;
 }
 
 .problems-table th,
-.problems-table td {
+.problems-table td,
+.resources-table th,
+.resources-table td {
   border: 1px solid #ccc;
   padding: 0.5rem;
   text-align: left;
 }
 
-.problems-table tr:hover {
+.problems-table tr:hover,
+.resources-table tr:hover {
   background-color: #f5f5f5;
   cursor: pointer;
 }
 
 .progress-section {
   margin-top: 2rem;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.progress-select {
+  min-width: 200px;
 }
 
 .placeholder {


### PR DESCRIPTION
## Summary
- Show resources in a table with name and status, matching the problems table
- Fix resource/problem links to open the proper URL
- Center section content and replace progress dropdown with a styled MUI select

## Testing
- `CI=true npm test` (frontend) – no tests found
- `npm test` (server) – missing script


------
https://chatgpt.com/codex/tasks/task_e_68b0c5b9bd148328b6f3f2cd35c0876a