### PR TITLE
Add random primary keys to problem, practice problem, and topic models

### DIFF
--- a/codespace/server/model/practiceProblemModel.js
+++ b/codespace/server/model/practiceProblemModel.js
@@ -1,6 +1,8 @@
 const mongoose = require('mongoose');
+const { randomUUID } = require('crypto');
 
 const practiceProblemSchema = new mongoose.Schema({
+  id: { type: String, default: randomUUID, unique: true },
   name: { type: String, required: true },
   link: { type: String, required: true },
   stage: {
@@ -13,6 +15,6 @@ const practiceProblemSchema = new mongoose.Schema({
   difficulty: { type: String, required: true },
   domain: { type: String, required: true },
   status: { type: String, default: 'Not Attempted' }
-});
+}, { id: false });
 
 module.exports = mongoose.model('PracticeProblem', practiceProblemSchema);

--- a/codespace/server/model/problemModel.js
+++ b/codespace/server/model/problemModel.js
@@ -1,11 +1,12 @@
 const mongoose = require('mongoose');
+const { randomUUID } = require('crypto');
 
 const problemSchema = new mongoose.Schema({
-  id: String,
+  id: { type: String, default: randomUUID, unique: true },
   problem_name: String,
   statement: String,
   sinput: String,
   soutput: String,
-});
+}, { id: false });
 
 module.exports = mongoose.model('Problem Packages', problemSchema);

--- a/codespace/server/model/topicModel.js
+++ b/codespace/server/model/topicModel.js
@@ -1,6 +1,8 @@
 const mongoose = require('mongoose');
+const { randomUUID } = require('crypto');
 
 const topicSchema = new mongoose.Schema({
+  id: { type: String, default: randomUUID, unique: true },
   stage: {
     type: String,
     enum: ['Bronze', 'Silver', 'Gold'],
@@ -13,7 +15,7 @@ const topicSchema = new mongoose.Schema({
     enum: ['not started', 'reading', 'finished'],
     default: 'not started',
   },
-});
+}, { id: false });
 
 // Ensure each stage/topic/subtopic combination is unique
 topicSchema.index({ stage: 1, topic: 1, subtopic: 1 }, { unique: true });


### PR DESCRIPTION
## Summary
- assign random UUID `id` field to practice problems
- add random UUID `id` to topic documents
- generate random `id` for problem packages

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b0c8f8693c83289a7283d625593467