### PR TITLE
Ignore null subtopics when loading topics

### DIFF
--- a/codespace/frontend/src/pages/ProblemsPage.js
+++ b/codespace/frontend/src/pages/ProblemsPage.js
@@ -41,10 +41,12 @@ function ProblemsPage() {
         const res = await axios.get(`${BACKEND_URL}/api/topics`);
         const grouped = {};
         Object.entries(res.data).forEach(([topicName, subs]) => {
-          subs.forEach(({ stage, subtopic }) => {
-            if (!grouped[stage]) grouped[stage] = {};
-            if (!grouped[stage][topicName]) grouped[stage][topicName] = [];
-            grouped[stage][topicName].push(subtopic);
+          const stage = subs[0]?.stage;
+          if (!stage) return;
+          if (!grouped[stage]) grouped[stage] = {};
+          if (!grouped[stage][topicName]) grouped[stage][topicName] = [];
+          subs.forEach(({ subtopic }) => {
+            if (subtopic) grouped[stage][topicName].push(subtopic);
           });
         });
         setTopics(grouped);

--- a/codespace/frontend/src/pages/ResourcesPage.js
+++ b/codespace/frontend/src/pages/ResourcesPage.js
@@ -51,10 +51,12 @@ function ResourcesPage() {
         const res = await axios.get(`${BACKEND_URL}/api/topics`);
         const grouped = {};
         Object.entries(res.data).forEach(([topicName, subs]) => {
-          subs.forEach(({ stage, subtopic }) => {
-            if (!grouped[stage]) grouped[stage] = {};
-            if (!grouped[stage][topicName]) grouped[stage][topicName] = [];
-            grouped[stage][topicName].push(subtopic);
+          const stage = subs[0]?.stage;
+          if (!stage) return;
+          if (!grouped[stage]) grouped[stage] = {};
+          if (!grouped[stage][topicName]) grouped[stage][topicName] = [];
+          subs.forEach(({ subtopic }) => {
+            if (subtopic) grouped[stage][topicName].push(subtopic);
           });
         });
         setTopics(grouped);


### PR DESCRIPTION
## Summary
- avoid blank subtopic entries by skipping null subtopics when grouping topics on problem and resource pages

## Testing
- `npm test` (codespace/server) *(fails: Missing script "test")*
- `npm test -- --watchAll=false` (codespace/frontend) *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0cb28d7b4832881d5ac5a220f60d6