### PR TITLE
Disable adding problems to past contests and link problems to details

### DIFF
--- a/codespace/frontend/src/pages/ContestDetailPage.js
+++ b/codespace/frontend/src/pages/ContestDetailPage.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { Box, Typography, Button, List, ListItem, TextField, MenuItem } from '@mui/material';
 import NavBar from '../components/NavBar';
 import BACKEND_URL from '../config';
@@ -11,6 +11,7 @@ function ContestDetailPage() {
   const [registered, setRegistered] = useState(false);
   const [problemList, setProblemList] = useState([]);
   const [selectedProblem, setSelectedProblem] = useState('');
+  const isPastContest = contest && new Date(contest.startTime) <= Date.now();
 
   useEffect(() => {
     async function fetchContest() {
@@ -149,35 +150,49 @@ function ContestDetailPage() {
               <Typography variant="h6">Problems</Typography>
               <List>
                 {contest.problems && contest.problems.length > 0 ? (
-                  contest.problems.map((p, idx) => (
-                    <ListItem key={idx}>{p}</ListItem>
-                  ))
+                  contest.problems.map((p, idx) => {
+                    const prob = problemList.find((pr) => pr.problem_name === p);
+                    return prob ? (
+                      <ListItem
+                        key={idx}
+                        component={Link}
+                        to={`/problems/${prob.id}`}
+                        sx={{ cursor: 'pointer' }}
+                      >
+                        {p}
+                      </ListItem>
+                    ) : (
+                      <ListItem key={idx}>{p}</ListItem>
+                    );
+                  })
                 ) : (
                   <ListItem>No problems available</ListItem>
                 )}
               </List>
-              <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
-                <TextField
-                  select
-                  label="Add Problem"
-                  value={selectedProblem}
-                  onChange={(e) => setSelectedProblem(e.target.value)}
-                  sx={{ minWidth: 200 }}
-                >
-                  {problemList.map((p) => (
-                    <MenuItem key={p.id} value={p.problem_name}>
-                      {p.problem_name}
-                    </MenuItem>
-                  ))}
-                </TextField>
-                <Button
-                  variant="contained"
-                  onClick={addProblem}
-                  disabled={!selectedProblem}
-                >
-                  Add
-                </Button>
-              </Box>
+              {!isPastContest && (
+                <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
+                  <TextField
+                    select
+                    label="Add Problem"
+                    value={selectedProblem}
+                    onChange={(e) => setSelectedProblem(e.target.value)}
+                    sx={{ minWidth: 200 }}
+                  >
+                    {problemList.map((p) => (
+                      <MenuItem key={p.id} value={p.problem_name}>
+                        {p.problem_name}
+                      </MenuItem>
+                    ))}
+                  </TextField>
+                  <Button
+                    variant="contained"
+                    onClick={addProblem}
+                    disabled={!selectedProblem}
+                  >
+                    Add
+                  </Button>
+                </Box>
+              )}
             </Box>
 
             <Box sx={{ mt: 4 }}>

--- a/codespace/server/routes/contests.js
+++ b/codespace/server/routes/contests.js
@@ -108,6 +108,9 @@ router.post('/:id/problems', async (req, res) => {
     if (!contest) {
       return res.status(404).json({ message: 'Contest not found' });
     }
+    if (new Date(contest.startTime) <= new Date()) {
+      return res.status(400).json({ message: 'Contest already started' });
+    }
     if (!contest.problems.includes(problem)) {
       contest.problems.push(problem);
       await contest.save();


### PR DESCRIPTION
## Summary
- Hide Add Problem controls for contests that have already started
- Prevent backend from accepting problem additions to past contests
- Make contest problem entries clickable links to the problem detail page

## Testing
- `CI=true npm test` *(server: missing test script)*
- `CI=true npm test` *(frontend: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0e3721c948328be86a1e5b55699a1