### PR TITLE
Improve leave room button styling

### DIFF
--- a/codespace/frontend/src/components/Room.js
+++ b/codespace/frontend/src/components/Room.js
@@ -6,8 +6,10 @@ import MainLHS from './LHS/MainLHS';
 import ChatBox from './ChatBox';
 import MembersList from './MembersList';
 import IconButton from '@mui/material/IconButton';
+import Button from '@mui/material/Button';
 import HeadsetMicIcon from '@mui/icons-material/HeadsetMic';
 import MicOffIcon from '@mui/icons-material/MicOff';
+import MeetingRoomIcon from '@mui/icons-material/MeetingRoom';
 import Modal from '@mui/material/Modal';
 import Box from '@mui/material/Box';
 import io from 'socket.io-client';
@@ -224,7 +226,15 @@ export default function Room() {
         <div className="editor-background">
         
         <div className='room-wrapper'>
-          <button className="leave-room-button" onClick={leaveRoom}>Leave Room</button>
+          <Button
+            className="leave-room-button"
+            variant="contained"
+            color="error"
+            startIcon={<MeetingRoomIcon />}
+            onClick={leaveRoom}
+          >
+            Leave Room
+          </Button>
           <aside className='left-sidebar'>
             <div className='members-section'>
               <IconButton variant="contained" color="primary" onClick={toggleMic}>

--- a/codespace/frontend/src/styles/RoomPage.css
+++ b/codespace/frontend/src/styles/RoomPage.css
@@ -113,22 +113,17 @@
 
 .leave-room-button {
   position: absolute;
-  margin: 3px;
+  top: 10px;
   right: 10px;
   z-index: 1000;
   padding: 0.5rem 1rem;
-  background: #d32f2f;
-  color: #fff;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
   font-size: 0.9rem;
-  transition: background 0.3s ease, transform 0.2s ease;
+  border-radius: 6px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  transition: transform 0.2s ease;
 }
 
-
 .leave-room-button:hover {
-  background: #9a0007;
-  transform: scale(1.03);
+  transform: scale(1.05);
 }
 


### PR DESCRIPTION
## Summary
- Replace plain leave-room button with a Material UI button and door icon
- Polish button styling with hover effect and shadow for smoother look

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68b19cacaeec8328b75a95d1f801db53