### PR TITLE
Add Python language support

### DIFF
--- a/codespace/server/model/submissionModel.js
+++ b/codespace/server/model/submissionModel.js
@@ -4,7 +4,8 @@ const submissionSchema = new mongoose.Schema({
   user: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
   problem: { type: String, required: true },
   code: { type: String, required: true },
-  verdict: { type: String, required: true }
+  verdict: { type: String, required: true },
+  language: { type: String, required: true }
 }, { timestamps: true });
 
 module.exports = mongoose.model('Submission', submissionSchema);

--- a/codespace/server/routes/submit.js
+++ b/codespace/server/routes/submit.js
@@ -25,12 +25,12 @@ function authenticate(req, res, next) {
 }
 
 router.post('/', authenticate, async (req, res) => {
-  const { code, problem_id } = req.body;
+  const { code, problem_id, language = 'cpp' } = req.body;
   if (!code || !problem_id) {
     return res.status(400).send('Code and problem ID are required.');
   }
 
-  const job = await submissionQueue.add('submissionProcess', { code: code, problemId: problem_id });
+  const job = await submissionQueue.add('submissionProcess', { code: code, problemId: problem_id, language });
   const verdictData = await waitforJobCompletion(submissionQueue, job);
 
   try {
@@ -39,6 +39,7 @@ router.post('/', authenticate, async (req, res) => {
       problem: problem_id,
       code,
       verdict: verdictData,
+      language,
     });
     await submission.save();
   } catch (err) {


### PR DESCRIPTION
## Summary
- allow choosing C++ or Python in the editor with default templates
- extend sandbox API and submission worker to run Python code
- store selected language in submissions

## Testing
- `npm test` (server) *(fails: Missing script "test")*
- `npm test -- --watchAll=false` (frontend) *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b468400d248328b584b2b03d0f770f