### PR TITLE
Switch language select to dropdown and enable editor scrolling

### DIFF
--- a/codespace/frontend/src/components/TextBox.js
+++ b/codespace/frontend/src/components/TextBox.js
@@ -125,27 +125,11 @@ export default function TextBox({socketRef,currentProbId}) {
     <div className="editor-wrapper">
         <div className="code-area">
             <div className="language-select">
-                <label>
-                    <input
-                        type="checkbox"
-                        checked={language === 'cpp'}
-                        onChange={() => handleLanguageChange('cpp')}
-                    /> C++
-                </label>
-                <label>
-                    <input
-                        type="checkbox"
-                        checked={language === 'python'}
-                        onChange={() => handleLanguageChange('python')}
-                    /> Python
-                </label>
-                <label>
-                    <input
-                        type="checkbox"
-                        checked={language === 'java'}
-                        onChange={() => handleLanguageChange('java')}
-                    /> Java
-                </label>
+                <select value={language} onChange={(e) => handleLanguageChange(e.target.value)}>
+                    <option value="cpp">C++</option>
+                    <option value="python">Python</option>
+                    <option value="java">Java</option>
+                </select>
             </div>
             <CodeMirror
                 value={textvalue}

--- a/codespace/frontend/src/styles/App.css
+++ b/codespace/frontend/src/styles/App.css
@@ -47,7 +47,11 @@ input {
   flex: 3;
   border: 1px solid #ddd;
   border-radius: 8px;
-  overflow: hidden;
+  overflow: auto;
+}
+
+.code-area .cm-editor {
+  height: 100%;
 }
 
 .io-wrapper {


### PR DESCRIPTION
## Summary
- Replace language checkboxes with dropdown selector in the code editor
- Allow code editor content to scroll when it exceeds the view

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68b46f73bfe883289785f21aecd7a099