### PR TITLE
docs: format default C++ sample

### DIFF
--- a/codespace/frontend/src/components/TextBox.js
+++ b/codespace/frontend/src/components/TextBox.js
@@ -12,7 +12,16 @@ import BACKEND_URL from '../config';
 const apiUrl = `${BACKEND_URL}/test`; // compilation sandbox endpoint
 const submitUrl = `${BACKEND_URL}/submit`;
 
-const defaultCpp = "#include <bits/stdc++.h>\nusing namespace std;\n\nint main(){\n int t;\n cin >> t;\n while(t--){\n\n }\n}";
+const defaultCpp = `#include <bits/stdc++.h>
+using namespace std;
+
+int main(){
+    int t;
+    cin >> t; // Reads the number of test cases
+    while(t--){
+
+    }
+}`;
 const defaultPython = `import sys\n\n\ndef solve():\n    pass\n\n\ndef main():\n    t = int(sys.stdin.readline())\n    for _ in range(t):\n        solve()\n\n\nif __name__ == "__main__":\n    main()\n`;
 
 const defaultJava = `import java.io.*;\nimport java.util.*;\n\npublic class Main {\n    public static void main(String[] args) throws Exception {\n        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));\n        int t = Integer.parseInt(br.readLine());\n        while (t-- > 0) {\n            // TODO: solve\n        }\n    }\n}\n`;

--- a/codespace/server/test-data/sandbox-WwuDwY/main.cpp
+++ b/codespace/server/test-data/sandbox-WwuDwY/main.cpp
@@ -11,7 +11,7 @@ int fx(int n){
 }
 int main(){
  int t;
- cin >> t;
+ cin >> t; // number of test cases
  while(t--){
   int n;
    cin>>n;


### PR DESCRIPTION
## Summary
- format default C++ snippet in TextBox to use a fenced template string and include an inline comment
- clarify sample sandbox main.cpp by commenting input line and adding trailing newline

## Testing
- `npm test`
- `cd ../server && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4e361fbb48328aaff8dde5c2a5c10