### PR TITLE
Render markdown in chat messages

### DIFF
--- a/codespace/frontend/README.md
+++ b/codespace/frontend/README.md
@@ -2,6 +2,13 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Markdown Rendering
+
+AI chat messages are rendered with [react-markdown](https://github.com/remarkjs/react-markdown) and GitHub Flavored Markdown via `remark-gfm`.
+Content is sanitized using `dompurify` and `rehype-sanitize` before being injected into the DOM.
+Code blocks are highlighted with `react-syntax-highlighter` and include a copy button.
+Links open in a new tab with `rel="noopener noreferrer"` for safety.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/codespace/frontend/package.json
+++ b/codespace/frontend/package.json
@@ -26,7 +26,12 @@
     "socket.io-client": "^4.7.2",
     "styled-components": "^6.1.0",
     "uuid": "^9.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "dompurify": "^3.2.6",
+    "react-markdown": "^10.1.0",
+    "react-syntax-highlighter": "^15.6.6",
+    "remark-gfm": "^4.0.1",
+    "rehype-sanitize": "^6.0.0"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -51,5 +56,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "jest": {
+    "transformIgnorePatterns": []
   }
 }

--- a/codespace/frontend/src/App.js
+++ b/codespace/frontend/src/App.js
@@ -12,6 +12,7 @@ import ResourcesPage from './pages/ResourcesPage';
 import SectionsPage from './pages/SectionsPage';
 import ContactPage from './pages/ContactPage';
 import ProfilePage from './pages/ProfilePage';
+import MarkdownTestPage from './pages/MarkdownTestPage';
 
 function App(){
   console.log(process.env);
@@ -29,6 +30,7 @@ function App(){
         <Route path="/contact" element={<ContactPage />} />
         <Route path="/profile" element={<ProfilePage />} />
         <Route path="/room" element={<Room />} />
+        <Route path="/markdown-test" element={<MarkdownTestPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
   );

--- a/codespace/frontend/src/components/AIChatBox.js
+++ b/codespace/frontend/src/components/AIChatBox.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import BACKEND_URL from '../config';
 import '../styles/ChatBox.css';
+import MarkdownMessage from './MarkdownMessage';
 
 export default function AIChatBox({ code }) {
   const [message, setMessage] = useState('');
@@ -46,7 +47,9 @@ export default function AIChatBox({ code }) {
       <div className="chat-messages">
         {messages.map((m, idx) => (
           <div key={idx} className={`chat-message${m.self ? ' self' : ''}`}>
-            <span className="chat-text">{m.text}</span>
+            <div className="chat-text">
+              <MarkdownMessage content={m.text} />
+            </div>
           </div>
         ))}
         {loading && (

--- a/codespace/frontend/src/components/ChatBox.js
+++ b/codespace/frontend/src/components/ChatBox.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import '../styles/ChatBox.css';
+import MarkdownMessage from './MarkdownMessage';
 
 export default function ChatBox({ socket, username }) {
   const [message, setMessage] = useState('');
@@ -63,7 +64,9 @@ export default function ChatBox({ socket, username }) {
                   <span className="chat-user">{m.username}:</span>
                 </>
               )}
-              <span className="chat-text">{m.msg}</span>
+              <div className="chat-text">
+                <MarkdownMessage content={m.msg} />
+              </div>
             </div>
           );
         })}

--- a/codespace/frontend/src/components/MarkdownMessage.js
+++ b/codespace/frontend/src/components/MarkdownMessage.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
+import DOMPurify from 'dompurify';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
+
+const schema = {
+  ...defaultSchema,
+  tagNames: [...defaultSchema.tagNames.filter((t) => t !== 'img'), 'input'],
+  attributes: {
+    ...defaultSchema.attributes,
+    a: [...(defaultSchema.attributes.a || []), 'target', 'rel'],
+    code: ['className'],
+    input: ['type', 'checked', 'disabled'],
+    th: ['colSpan', 'rowSpan', 'align'],
+    td: ['colSpan', 'rowSpan', 'align']
+  }
+};
+
+function Code({ inline, className, children, ...props }) {
+  const match = /language-(\w+)/.exec(className || '');
+  const code = String(children).replace(/\n$/, '');
+  const handleCopy = () => {
+    navigator.clipboard.writeText(code);
+  };
+  if (inline) {
+    return (
+      <code className={className} {...props}>
+        {children}
+      </code>
+    );
+  }
+  return (
+    <div className="code-block">
+      <button className="copy-btn" onClick={handleCopy} aria-label="Copy code">
+        Copy
+      </button>
+      <SyntaxHighlighter
+        style={vscDarkPlus}
+        language={match ? match[1] : undefined}
+        PreTag="div"
+        {...props}
+      >
+        {code}
+      </SyntaxHighlighter>
+    </div>
+  );
+}
+
+export function renderMarkdownToSafeHtml(markdown) {
+  const clean = DOMPurify.sanitize(markdown);
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      rehypePlugins={[[rehypeSanitize, schema]]}
+      components={{
+        a: ({ node, ...props }) => (
+          <a {...props} target="_blank" rel="noopener noreferrer" />
+        ),
+        code: Code
+      }}
+    >
+      {clean}
+    </ReactMarkdown>
+  );
+}
+
+export default function MarkdownMessage({ content }) {
+  return <div className="markdown-content">{renderMarkdownToSafeHtml(content)}</div>;
+}
+

--- a/codespace/frontend/src/components/__tests__/MarkdownMessage.test.js
+++ b/codespace/frontend/src/components/__tests__/MarkdownMessage.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import MarkdownMessage from '../MarkdownMessage';
+
+describe('MarkdownMessage', () => {
+  test('renders list, bold, inline code and fenced block', () => {
+    const md = `* **\`cin >> t;\`** reads an integer\n\n\
+\`\`\`c++\nint main() {\n return 0;\n}\n\`\`\``;
+    render(<MarkdownMessage content={md} />);
+    expect(screen.getByText('cin >> t;', { selector: 'code' })).toBeInTheDocument();
+    expect(screen.getByLabelText(/copy code/i)).toBeInTheDocument();
+  });
+
+  test('renders links safely', () => {
+    const md = `[OpenAI](https://openai.com)`;
+    render(<MarkdownMessage content={md} />);
+    const link = screen.getByRole('link', { name: 'OpenAI' });
+    expect(link).toHaveAttribute('href', 'https://openai.com');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  test('renders tables and task lists', () => {
+    const md = `| a | b |\n| --- | --- |\n| 1 | 2 |\n\n- [x] done\n- [ ] todo`;
+    render(<MarkdownMessage content={md} />);
+    expect(screen.getByText('a')).toBeInTheDocument();
+    const boxes = screen.getAllByRole('checkbox');
+    expect(boxes[0]).toBeChecked();
+    expect(boxes[1]).not.toBeChecked();
+  });
+
+  test('strips unsafe html', () => {
+    const md = '<img src=x onerror=alert(1)>'; // should not render an image
+    render(<MarkdownMessage content={md} />);
+    expect(screen.queryByRole('img')).toBeNull();
+  });
+});
+

--- a/codespace/frontend/src/pages/MarkdownTestPage.js
+++ b/codespace/frontend/src/pages/MarkdownTestPage.js
@@ -1,0 +1,19 @@
+import React, { useState } from 'react';
+import MarkdownMessage from '../components/MarkdownMessage';
+
+const sample = `# Markdown demo\n* **\`cin >> t;\`** reads an integer\n\n\`\`\`c++\nint main() { return 0; }\n\`\`\`\n\n- [x] done\n- [ ] todo\n\n[OpenAI](https://openai.com)`;
+
+export default function MarkdownTestPage() {
+  const [text, setText] = useState(sample);
+  return (
+    <div style={{ padding: '1rem' }}>
+      <textarea
+        style={{ width: '100%', height: '150px', marginBottom: '1rem' }}
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <MarkdownMessage content={text} />
+    </div>
+  );
+}
+

--- a/codespace/frontend/src/setupTests.js
+++ b/codespace/frontend/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/codespace/frontend/src/styles/ChatBox.css
+++ b/codespace/frontend/src/styles/ChatBox.css
@@ -61,6 +61,33 @@
   white-space: pre-wrap;
 }
 
+.chat-text pre {
+  background: #f0f0f0;
+  padding: 0.5rem;
+  border-radius: 4px;
+  overflow-x: auto;
+}
+
+.code-block {
+  position: relative;
+}
+
+.copy-btn {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  padding: 0.2rem 0.4rem;
+  font-size: 0.75rem;
+  border: none;
+  border-radius: 4px;
+  background: #e0e0e0;
+  cursor: pointer;
+}
+
+.copy-btn:hover {
+  background: #d5d5d5;
+}
+
 .chat-spinner {
   width: 24px;
   height: 24px;


### PR DESCRIPTION
## Summary
- render chat messages with MarkdownMessage component using react-markdown, sanitization, and syntax highlighting
- add copy button and styles for code blocks
- document markdown support and add a demo page

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot read properties of undefined (reading '2') in micromark-extension-gfm-table)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cdb2ebb48328b5f8ab6a44bf1766