### PR TITLE
Arrange chat action buttons below input fields

### DIFF
--- a/codespace/frontend/src/components/AIChatBox.js
+++ b/codespace/frontend/src/components/AIChatBox.js
@@ -66,9 +66,11 @@ export default function AIChatBox({ code }) {
           value={message}
           onChange={(e) => setMessage(e.target.value)}
         />
-        <button type="button" onClick={() => send('normal')} disabled={loading}>Send</button>
-        <button type="button" onClick={() => send('fix')} disabled={loading}>Fix</button>
-        <button type="button" onClick={() => send('explain')} disabled={loading}>Explain</button>
+        <div className="chat-actions">
+          <button type="button" onClick={() => send('normal')} disabled={loading}>Send</button>
+          <button type="button" onClick={() => send('fix')} disabled={loading}>Fix</button>
+          <button type="button" onClick={() => send('explain')} disabled={loading}>Explain</button>
+        </div>
       </div>
     </div>
   );

--- a/codespace/frontend/src/components/ChatBox.js
+++ b/codespace/frontend/src/components/ChatBox.js
@@ -79,7 +79,9 @@ export default function ChatBox({ socket, username }) {
           value={message}
           onChange={(e) => setMessage(e.target.value)}
         />
-        <button type="submit">Send</button>
+        <div className="chat-actions">
+          <button type="submit">Send</button>
+        </div>
       </form>
     </div>
   );

--- a/codespace/frontend/src/styles/ChatBox.css
+++ b/codespace/frontend/src/styles/ChatBox.css
@@ -104,10 +104,11 @@
   }
 }
 
-/* Input section with message box and send button */
+/* Input section with message box and action buttons */
 .chat-input {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: stretch;
   border-top: 1px solid #ccc;
   background: #fff;
   padding: 0.5rem;
@@ -123,7 +124,13 @@
   background: #fff;
 }
 
-.chat-input button {
+.chat-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.chat-actions button {
+  flex: 1;
   padding: 0.5rem 1rem;
   border: none;
   border-radius: 4px;
@@ -135,6 +142,6 @@
   justify-content: center;
 }
 
-.chat-input button:hover {
+.chat-actions button:hover {
   background: #115293;
 }


### PR DESCRIPTION
## Summary
- Stack chat send button below message input
- Group AI chat actions under input box and style vertically
- Adjust chat styles for new vertical layout

## Testing
- `CI=true npm test --silent` *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*

------
https://chatgpt.com/codex/tasks/task_e_68b5eadb0ae083289dd0de3bc1aa7650