### PR TITLE
Implement role-based access control

### DIFF
--- a/codespace/frontend/src/App.js
+++ b/codespace/frontend/src/App.js
@@ -12,6 +12,7 @@ import ResourcesPage from './pages/ResourcesPage';
 import SectionsPage from './pages/SectionsPage';
 import ContactPage from './pages/ContactPage';
 import ProfilePage from './pages/ProfilePage';
+import AdminPage from './pages/AdminPage';
 import MarkdownTestPage from './pages/MarkdownTestPage';
 
 function App(){
@@ -30,6 +31,7 @@ function App(){
         <Route path="/contact" element={<ContactPage />} />
         <Route path="/profile" element={<ProfilePage />} />
         <Route path="/room" element={<Room />} />
+        <Route path="/admin" element={<AdminPage />} />
         <Route path="/markdown-test" element={<MarkdownTestPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/codespace/frontend/src/components/NavBar.js
+++ b/codespace/frontend/src/components/NavBar.js
@@ -11,6 +11,7 @@ import userIcon from '../assets/images/user.svg';
 
 function NavBar() {
   const [loggedIn, setLoggedIn] = useState(false);
+  const [role, setRole] = useState(null);
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
   const navigate = useNavigate();
@@ -18,6 +19,7 @@ function NavBar() {
   useEffect(() => {
     const token = localStorage.getItem('token');
     setLoggedIn(!!token);
+    setRole(localStorage.getItem("role"));
   }, []);
 
   const handleMenu = (event) => {
@@ -30,6 +32,8 @@ function NavBar() {
 
   const handleLogout = () => {
     localStorage.removeItem('token');
+    localStorage.removeItem('role');
+    setRole(null);
     setLoggedIn(false);
     handleClose();
     navigate('/login');
@@ -50,6 +54,7 @@ function NavBar() {
         <li><Link to="/contests">Contests</Link></li>
         <li><Link to="/rooms">Rooms</Link></li>
         <li><Link to="/contact">Contact Us</Link></li>
+        {(role === 'admin' || role === 'superadmin') && <li><Link to="/admin">Admin</Link></li>}
         {!loggedIn && <li><Link to="/login">Login</Link></li>}
         {loggedIn && (
           <li className="profile-container">

--- a/codespace/frontend/src/pages/AdminPage.js
+++ b/codespace/frontend/src/pages/AdminPage.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+
+const AdminPage = () => {
+  const role = localStorage.getItem('role');
+  if (role !== 'admin' && role !== 'superadmin') {
+    return <Navigate to="/" replace />;
+  }
+  return (
+    <div>
+      <h2>Admin Dashboard</h2>
+      {role === 'superadmin' ? (
+        <p>Super Admin privileges: manage admins and users.</p>
+      ) : (
+        <p>Admin privileges: manage users.</p>
+      )}
+    </div>
+  );
+};
+
+export default AdminPage;

--- a/codespace/frontend/src/pages/LoginPage.js
+++ b/codespace/frontend/src/pages/LoginPage.js
@@ -28,6 +28,7 @@ function LoginPage() {
         const payload = JSON.parse(atob(data.token.split('.')[1]));
         localStorage.setItem('username', payload.username);
         localStorage.setItem('userid', payload.id);
+        localStorage.setItem('role', payload.role);
       } catch (e) {
         console.error('Failed to decode token');
       }

--- a/codespace/server/app.js
+++ b/codespace/server/app.js
@@ -10,7 +10,8 @@ const auth = require("./routes/auth")
 const roomsRoute = require("./routes/rooms");
 const contestsRoute = require("./routes/contests")
 const authMiddleware = require("./middleware/authMiddleware")
-const usersRoute = require("./routes/users")
+const usersRoute = require("./routes/users");
+const adminRoute = require("./routes/admin");
 const resourcesRoute = require("./routes/resources");
 const topicsRoute = require("./routes/topics");
 const problemsRoute = require("./routes/problems");
@@ -42,7 +43,8 @@ app.use('/api/auth',auth)
 app.use('/api',api1)
 app.use('/api/contests',contestsRoute)
 app.use('/api/rooms', authMiddleware, roomsRoute)
-app.use('/api/users', usersRoute)
+app.use('/api/users', usersRoute);
+app.use('/api/admin', adminRoute);
 app.use('/api/resources', resourcesRoute)
 app.use('/api/topics', topicsRoute)
 app.use('/api/problems', problemsRoute)

--- a/codespace/server/middleware/roleMiddleware.js
+++ b/codespace/server/middleware/roleMiddleware.js
@@ -1,0 +1,8 @@
+module.exports = function (...allowed) {
+  return function (req, res, next) {
+    if (!req.user || !allowed.includes(req.user.role)) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+    next();
+  };
+};

--- a/codespace/server/model/userModel.js
+++ b/codespace/server/model/userModel.js
@@ -3,7 +3,8 @@ const mongoose = require('mongoose');
 const userSchema = new mongoose.Schema({
   username: { type: String, required: true, unique: true },
   email: { type: String, required: true, unique: true },
-  password: { type: String, required: true }
+  password: { type: String, required: true },
+  role: { type: String, enum: ['user','admin','superadmin'], default: 'user' }
 });
 
 module.exports = mongoose.model('User', userSchema);

--- a/codespace/server/package.json
+++ b/codespace/server/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node app",
-    "dev": "nodemon app"
+    "dev": "nodemon app",
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -26,6 +27,7 @@
     "dotenv": "^16.3.1"
   },
   "devDependencies": {
-    "nodemon": "^3.0.1"
+    "nodemon": "^3.0.1",
+    "jest": "^29.7.0"
   }
 }

--- a/codespace/server/routes/admin.js
+++ b/codespace/server/routes/admin.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const User = require('../model/userModel');
+const auth = require('../middleware/authMiddleware');
+const permit = require('../middleware/roleMiddleware');
+
+const router = express.Router();
+
+router.use(auth);
+
+// List users - accessible by admins and super admins
+router.get('/users', permit('admin', 'superadmin'), async (req, res) => {
+  const users = await User.find({}, '-password');
+  res.json(users);
+});
+
+// Promote a user to admin - only super admins
+router.post('/users/:id/promote', permit('superadmin'), async (req, res) => {
+  const user = await User.findById(req.params.id);
+  if (!user) return res.status(404).json({ message: 'User not found' });
+  user.role = 'admin';
+  await user.save();
+  res.json({ message: 'User promoted to admin' });
+});
+
+// Demote an admin to user - only super admins
+router.post('/users/:id/demote', permit('superadmin'), async (req, res) => {
+  const user = await User.findById(req.params.id);
+  if (!user) return res.status(404).json({ message: 'User not found' });
+  user.role = 'user';
+  await user.save();
+  res.json({ message: 'User demoted to user' });
+});
+
+module.exports = router;

--- a/codespace/server/routes/auth.js
+++ b/codespace/server/routes/auth.js
@@ -10,14 +10,14 @@ const url = process.env.MONGODB_URI || 'mongodb://localhost:27017/graduation_pro
 mongoose.connect(url);
 
 router.post('/register', async (req, res) => {
-  const { username, email, password } = req.body;
+  const { username, email, password, role } = req.body;
   try {
     const existing = await User.findOne({ $or: [{ username }, { email }] });
     if (existing) {
       return res.status(400).json({ message: 'User already exists' });
     }
     const hashed = await bcrypt.hash(password, 10);
-    const user = new User({ username, email, password: hashed });
+    const user = new User({ username, email, password: hashed, role: role || 'user' });
     await user.save();
     res.json({ message: 'User created' });
   } catch (err) {
@@ -39,7 +39,7 @@ router.post('/login', async (req, res) => {
     }
     console.log(user);
     const token = jwt.sign(
-      { id: user._id, username: user.username },
+      { id: user._id, username: user.username, role: user.role },
       process.env.JWT_SECRET || 'changeme',
       { expiresIn: '1h' }
     );

--- a/codespace/server/tests/roleMiddleware.test.js
+++ b/codespace/server/tests/roleMiddleware.test.js
@@ -1,0 +1,17 @@
+const authorize = require('../middleware/roleMiddleware');
+
+test('allows user with required role', () => {
+  const req = { user: { role: 'admin' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  const next = jest.fn();
+  authorize('admin')(req, res, next);
+  expect(next).toHaveBeenCalled();
+});
+
+test('blocks user with insufficient role', () => {
+  const req = { user: { role: 'user' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  const next = jest.fn();
+  authorize('admin')(req, res, next);
+  expect(res.status).toHaveBeenCalledWith(403);
+});


### PR DESCRIPTION
## Summary
- add `role` to user schema and include role in auth flow
- introduce role-based middleware and admin management routes
- surface admin-only UI and navigation in frontend
- include unit tests for role middleware

## Testing
- `npm test` (fails: npm: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68b5f083c89c83289d7f1fc5b2a2d73d