### PR TITLE
Hide admin features for user role

### DIFF
--- a/codespace/frontend/src/components/ProblemSidebar.js
+++ b/codespace/frontend/src/components/ProblemSidebar.js
@@ -23,152 +23,157 @@ function ProblemSidebar({
   handleTopicChange,
   selectedSubtopic,
   setSelectedSubtopic,
+  isAdmin,
 }) {
   return (
     <div className="left-menu">
-      <div className="button-group">
-        <button onClick={() => setShowForm(!showForm)}>New Problem</button>
-        <button onClick={() => setShowTopicForm(!showTopicForm)}>New Topic</button>
-        <button onClick={() => setShowSubtopicForm(!showSubtopicForm)}>New Subtopic</button>
-      </div>
-      {showForm && (
-        <form className="add-resource-form" onSubmit={addProblem}>
-          <input
-            type="text"
-            name="name"
-            placeholder="Name"
-            value={formData.name}
-            onChange={handleFormChange}
-            required
-          />
-          <input
-            type="text"
-            name="link"
-            placeholder="Link"
-            value={formData.link}
-            onChange={handleFormChange}
-            required
-          />
-          <select
-            name="stage"
-            value={formData.stage}
-            onChange={handleFormChange}
-            required
-          >
-            <option value="">Select Stage</option>
-            {['Bronze', 'Silver', 'Gold'].map((s) => (
-              <option key={s} value={s}>
-                {s}
-              </option>
-            ))}
-          </select>
-          <select
-            name="topic"
-            value={formData.topic}
-            onChange={handleFormChange}
-            disabled={!formData.stage}
-            required
-          >
-            <option value="">Select Topic</option>
-            {formData.stage &&
-              Object.keys(topics[formData.stage] || {}).map((topic) => (
-                <option key={topic} value={topic}>
-                  {topic}
-                </option>
-              ))}
-          </select>
-          <select
-            name="subtopic"
-            value={formData.subtopic}
-            onChange={handleFormChange}
-            disabled={!formData.topic}
-            required
-          >
-            <option value="">Select Subtopic</option>
-            {formData.stage &&
-              formData.topic &&
-              topics[formData.stage][formData.topic].map((sub) => (
-                <option key={sub} value={sub}>
-                  {sub}
-                </option>
-              ))}
-          </select>
-          <select
-            name="difficulty"
-            value={formData.difficulty}
-            onChange={handleFormChange}
-            required
-          >
-            <option value="">Select Difficulty</option>
-            <option value="Easy">Easy</option>
-            <option value="Medium">Medium</option>
-            <option value="Hard">Hard</option>
-            <option value="Insane">Insane</option>
-          </select>
-          <button type="submit">Add</button>
-        </form>
-      )}
-      {showTopicForm && (
-        <form className="add-topic-form" onSubmit={addTopic}>
-          <select
-            value={newTopic.stage}
-            onChange={(e) => setNewTopic((prev) => ({ ...prev, stage: e.target.value }))}
-            required
-          >
-            <option value="">Select Stage</option>
-            {['Bronze', 'Silver', 'Gold'].map((s) => (
-              <option key={s} value={s}>
-                {s}
-              </option>
-            ))}
-          </select>
-          <input
-            type="text"
-            value={newTopic.name}
-            onChange={(e) => setNewTopic((prev) => ({ ...prev, name: e.target.value }))}
-            placeholder="Topic Name"
-            required
-          />
-          <button type="submit">Add</button>
-        </form>
-      )}
-      {showSubtopicForm && (
-        <form className="add-subtopic-form" onSubmit={addSubtopic}>
-          <select
-            value={newSubtopic.stage}
-            onChange={(e) => setNewSubtopic((prev) => ({ ...prev, stage: e.target.value, topic: '' }))}
-            required
-          >
-            <option value="">Select Stage</option>
-            {['Bronze', 'Silver', 'Gold'].map((s) => (
-              <option key={s} value={s}>
-                {s}
-              </option>
-            ))}
-          </select>
-          <select
-            value={newSubtopic.topic}
-            onChange={(e) => setNewSubtopic((prev) => ({ ...prev, topic: e.target.value }))}
-            disabled={!newSubtopic.stage}
-            required
-          >
-            <option value="">Select Topic</option>
-            {newSubtopic.stage &&
-              Object.keys(topics[newSubtopic.stage] || {}).map((topic) => (
-                <option key={topic} value={topic}>
-                  {topic}
-                </option>
-              ))}
-          </select>
-          <input
-            type="text"
-            value={newSubtopic.name}
-            onChange={(e) => setNewSubtopic((prev) => ({ ...prev, name: e.target.value }))}
-            placeholder="Subtopic Name"
-            required
-          />
-          <button type="submit">Add</button>
-        </form>
+      {isAdmin && (
+        <>
+          <div className="button-group">
+            <button onClick={() => setShowForm(!showForm)}>New Problem</button>
+            <button onClick={() => setShowTopicForm(!showTopicForm)}>New Topic</button>
+            <button onClick={() => setShowSubtopicForm(!showSubtopicForm)}>New Subtopic</button>
+          </div>
+          {showForm && (
+            <form className="add-resource-form" onSubmit={addProblem}>
+              <input
+                type="text"
+                name="name"
+                placeholder="Name"
+                value={formData.name}
+                onChange={handleFormChange}
+                required
+              />
+              <input
+                type="text"
+                name="link"
+                placeholder="Link"
+                value={formData.link}
+                onChange={handleFormChange}
+                required
+              />
+              <select
+                name="stage"
+                value={formData.stage}
+                onChange={handleFormChange}
+                required
+              >
+                <option value="">Select Stage</option>
+                {['Bronze', 'Silver', 'Gold'].map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+              <select
+                name="topic"
+                value={formData.topic}
+                onChange={handleFormChange}
+                disabled={!formData.stage}
+                required
+              >
+                <option value="">Select Topic</option>
+                {formData.stage &&
+                  Object.keys(topics[formData.stage] || {}).map((topic) => (
+                    <option key={topic} value={topic}>
+                      {topic}
+                    </option>
+                  ))}
+              </select>
+              <select
+                name="subtopic"
+                value={formData.subtopic}
+                onChange={handleFormChange}
+                disabled={!formData.topic}
+                required
+              >
+                <option value="">Select Subtopic</option>
+                {formData.stage &&
+                  formData.topic &&
+                  topics[formData.stage][formData.topic].map((sub) => (
+                    <option key={sub} value={sub}>
+                      {sub}
+                    </option>
+                  ))}
+              </select>
+              <select
+                name="difficulty"
+                value={formData.difficulty}
+                onChange={handleFormChange}
+                required
+              >
+                <option value="">Select Difficulty</option>
+                <option value="Easy">Easy</option>
+                <option value="Medium">Medium</option>
+                <option value="Hard">Hard</option>
+                <option value="Insane">Insane</option>
+              </select>
+              <button type="submit">Add</button>
+            </form>
+          )}
+          {showTopicForm && (
+            <form className="add-topic-form" onSubmit={addTopic}>
+              <select
+                value={newTopic.stage}
+                onChange={(e) => setNewTopic((prev) => ({ ...prev, stage: e.target.value }))}
+                required
+              >
+                <option value="">Select Stage</option>
+                {['Bronze', 'Silver', 'Gold'].map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+              <input
+                type="text"
+                value={newTopic.name}
+                onChange={(e) => setNewTopic((prev) => ({ ...prev, name: e.target.value }))}
+                placeholder="Topic Name"
+                required
+              />
+              <button type="submit">Add</button>
+            </form>
+          )}
+          {showSubtopicForm && (
+            <form className="add-subtopic-form" onSubmit={addSubtopic}>
+              <select
+                value={newSubtopic.stage}
+                onChange={(e) => setNewSubtopic((prev) => ({ ...prev, stage: e.target.value, topic: '' }))}
+                required
+              >
+                <option value="">Select Stage</option>
+                {['Bronze', 'Silver', 'Gold'].map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+              <select
+                value={newSubtopic.topic}
+                onChange={(e) => setNewSubtopic((prev) => ({ ...prev, topic: e.target.value }))}
+                disabled={!newSubtopic.stage}
+                required
+              >
+                <option value="">Select Topic</option>
+                {newSubtopic.stage &&
+                  Object.keys(topics[newSubtopic.stage] || {}).map((topic) => (
+                    <option key={topic} value={topic}>
+                      {topic}
+                    </option>
+                  ))}
+              </select>
+              <input
+                type="text"
+                value={newSubtopic.name}
+                onChange={(e) => setNewSubtopic((prev) => ({ ...prev, name: e.target.value }))}
+                placeholder="Subtopic Name"
+                required
+              />
+              <button type="submit">Add</button>
+            </form>
+          )}
+        </>
       )}
       <select value={selectedStage} onChange={handleStageChange}>
         <option value="">All Stages</option>

--- a/codespace/frontend/src/components/ResourcesSidebar.js
+++ b/codespace/frontend/src/components/ResourcesSidebar.js
@@ -23,140 +23,145 @@ function ResourcesSidebar({
   handleTopicChange,
   selectedSubtopic,
   setSelectedSubtopic,
+  isAdmin,
 }) {
   return (
     <div className="left-menu">
-      <div className="button-group">
-        <button onClick={() => setShowForm(!showForm)}>New Resource</button>
-        <button onClick={() => setShowTopicForm(!showTopicForm)}>New Topic</button>
-        <button onClick={() => setShowSubtopicForm(!showSubtopicForm)}>New Subtopic</button>
-      </div>
-      {showForm && (
-        <form className="add-resource-form" onSubmit={addResource}>
-          <input
-            type="text"
-            name="name"
-            placeholder="Name"
-            value={formData.name}
-            onChange={handleFormChange}
-            required
-          />
-          <input
-            type="text"
-            name="link"
-            placeholder="Link"
-            value={formData.link}
-            onChange={handleFormChange}
-            required
-          />
-          <select
-            name="stage"
-            value={formData.stage}
-            onChange={handleFormChange}
-            required
-          >
-            <option value="">Select Stage</option>
-            {['Bronze', 'Silver', 'Gold'].map((s) => (
-              <option key={s} value={s}>
-                {s}
-              </option>
-            ))}
-          </select>
-          <select
-            name="topic"
-            value={formData.topic}
-            onChange={handleFormChange}
-            disabled={!formData.stage}
-            required
-          >
-            <option value="">Select Topic</option>
-            {formData.stage &&
-              Object.keys(topics[formData.stage] || {}).map((topic) => (
-                <option key={topic} value={topic}>
-                  {topic}
-                </option>
-              ))}
-          </select>
-          <select
-            name="subtopic"
-            value={formData.subtopic}
-            onChange={handleFormChange}
-            disabled={!formData.topic}
-            required
-          >
-            <option value="">Select Subtopic</option>
-            {formData.stage &&
-              formData.topic &&
-              topics[formData.stage][formData.topic].map((sub) => (
-                <option key={sub} value={sub}>
-                  {sub}
-                </option>
-              ))}
-          </select>
-          <button type="submit">Add</button>
-        </form>
-      )}
-      {showTopicForm && (
-        <form className="add-topic-form" onSubmit={addTopic}>
-          <select
-            value={newTopic.stage}
-            onChange={(e) => setNewTopic((prev) => ({ ...prev, stage: e.target.value }))}
-            required
-          >
-            <option value="">Select Stage</option>
-            {['Bronze', 'Silver', 'Gold'].map((s) => (
-              <option key={s} value={s}>
-                {s}
-              </option>
-            ))}
-          </select>
-          <input
-            type="text"
-            value={newTopic.name}
-            onChange={(e) => setNewTopic((prev) => ({ ...prev, name: e.target.value }))}
-            placeholder="Topic Name"
-            required
-          />
-          <button type="submit">Add</button>
-        </form>
-      )}
-      {showSubtopicForm && (
-        <form className="add-subtopic-form" onSubmit={addSubtopic}>
-          <select
-            value={newSubtopic.stage}
-            onChange={(e) => setNewSubtopic((prev) => ({ ...prev, stage: e.target.value, topic: '' }))}
-            required
-          >
-            <option value="">Select Stage</option>
-            {['Bronze', 'Silver', 'Gold'].map((s) => (
-              <option key={s} value={s}>
-                {s}
-              </option>
-            ))}
-          </select>
-          <select
-            value={newSubtopic.topic}
-            onChange={(e) => setNewSubtopic((prev) => ({ ...prev, topic: e.target.value }))}
-            disabled={!newSubtopic.stage}
-            required
-          >
-            <option value="">Select Topic</option>
-            {newSubtopic.stage &&
-              Object.keys(topics[newSubtopic.stage] || {}).map((topic) => (
-                <option key={topic} value={topic}>
-                  {topic}
-                </option>
-              ))}
-          </select>
-          <input
-            type="text"
-            value={newSubtopic.name}
-            onChange={(e) => setNewSubtopic((prev) => ({ ...prev, name: e.target.value }))}
-            placeholder="Subtopic Name"
-            required
-          />
-          <button type="submit">Add</button>
-        </form>
+      {isAdmin && (
+        <>
+          <div className="button-group">
+            <button onClick={() => setShowForm(!showForm)}>New Resource</button>
+            <button onClick={() => setShowTopicForm(!showTopicForm)}>New Topic</button>
+            <button onClick={() => setShowSubtopicForm(!showSubtopicForm)}>New Subtopic</button>
+          </div>
+          {showForm && (
+            <form className="add-resource-form" onSubmit={addResource}>
+              <input
+                type="text"
+                name="name"
+                placeholder="Name"
+                value={formData.name}
+                onChange={handleFormChange}
+                required
+              />
+              <input
+                type="text"
+                name="link"
+                placeholder="Link"
+                value={formData.link}
+                onChange={handleFormChange}
+                required
+              />
+              <select
+                name="stage"
+                value={formData.stage}
+                onChange={handleFormChange}
+                required
+              >
+                <option value="">Select Stage</option>
+                {['Bronze', 'Silver', 'Gold'].map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+              <select
+                name="topic"
+                value={formData.topic}
+                onChange={handleFormChange}
+                disabled={!formData.stage}
+                required
+              >
+                <option value="">Select Topic</option>
+                {formData.stage &&
+                  Object.keys(topics[formData.stage] || {}).map((topic) => (
+                    <option key={topic} value={topic}>
+                      {topic}
+                    </option>
+                  ))}
+              </select>
+              <select
+                name="subtopic"
+                value={formData.subtopic}
+                onChange={handleFormChange}
+                disabled={!formData.topic}
+                required
+              >
+                <option value="">Select Subtopic</option>
+                {formData.stage &&
+                  formData.topic &&
+                  topics[formData.stage][formData.topic].map((sub) => (
+                    <option key={sub} value={sub}>
+                      {sub}
+                    </option>
+                  ))}
+              </select>
+              <button type="submit">Add</button>
+            </form>
+          )}
+          {showTopicForm && (
+            <form className="add-topic-form" onSubmit={addTopic}>
+              <select
+                value={newTopic.stage}
+                onChange={(e) => setNewTopic((prev) => ({ ...prev, stage: e.target.value }))}
+                required
+              >
+                <option value="">Select Stage</option>
+                {['Bronze', 'Silver', 'Gold'].map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+              <input
+                type="text"
+                value={newTopic.name}
+                onChange={(e) => setNewTopic((prev) => ({ ...prev, name: e.target.value }))}
+                placeholder="Topic Name"
+                required
+              />
+              <button type="submit">Add</button>
+            </form>
+          )}
+          {showSubtopicForm && (
+            <form className="add-subtopic-form" onSubmit={addSubtopic}>
+              <select
+                value={newSubtopic.stage}
+                onChange={(e) => setNewSubtopic((prev) => ({ ...prev, stage: e.target.value, topic: '' }))}
+                required
+              >
+                <option value="">Select Stage</option>
+                {['Bronze', 'Silver', 'Gold'].map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+              <select
+                value={newSubtopic.topic}
+                onChange={(e) => setNewSubtopic((prev) => ({ ...prev, topic: e.target.value }))}
+                disabled={!newSubtopic.stage}
+                required
+              >
+                <option value="">Select Topic</option>
+                {newSubtopic.stage &&
+                  Object.keys(topics[newSubtopic.stage] || {}).map((topic) => (
+                    <option key={topic} value={topic}>
+                      {topic}
+                    </option>
+                  ))}
+              </select>
+              <input
+                type="text"
+                value={newSubtopic.name}
+                onChange={(e) => setNewSubtopic((prev) => ({ ...prev, name: e.target.value }))}
+                placeholder="Subtopic Name"
+                required
+              />
+              <button type="submit">Add</button>
+            </form>
+          )}
+        </>
       )}
       <select value={selectedStage} onChange={handleStageChange}>
         <option value="">All Stages</option>

--- a/codespace/frontend/src/pages/ContestDetailPage.js
+++ b/codespace/frontend/src/pages/ContestDetailPage.js
@@ -12,6 +12,8 @@ function ContestDetailPage() {
   const [problemList, setProblemList] = useState([]);
   const [selectedProblem, setSelectedProblem] = useState('');
   const isPastContest = contest && new Date(contest.startTime) <= Date.now();
+  const role = localStorage.getItem('role');
+  const isAdmin = role === 'admin' || role === 'superadmin';
 
   useEffect(() => {
     async function fetchContest() {
@@ -112,6 +114,7 @@ function ContestDetailPage() {
   };
 
   const addProblem = async () => {
+    if (!isAdmin) return;
     try {
       const res = await fetch(`${BACKEND_URL}/api/contests/${id}/problems`, {
         method: 'POST',
@@ -169,7 +172,7 @@ function ContestDetailPage() {
                   <ListItem>No problems available</ListItem>
                 )}
               </List>
-              {!isPastContest && (
+              {!isPastContest && isAdmin && (
                 <Box sx={{ display: 'flex', gap: 2, mt: 2 }}>
                   <TextField
                     select

--- a/codespace/frontend/src/pages/ContestPage.js
+++ b/codespace/frontend/src/pages/ContestPage.js
@@ -40,6 +40,8 @@ function ContestPage() {
   const [past, setPast] = useState([]);
   const [form, setForm] = useState({ name: '', startTime: '', duration: '' });
   const userId = localStorage.getItem('userid');
+  const role = localStorage.getItem('role');
+  const isAdmin = role === 'admin' || role === 'superadmin';
 
   const handleInputChange = (e) => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -82,6 +84,7 @@ function ContestPage() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (!isAdmin) return;
     try {
       const res = await fetch(`${BACKEND_URL}/api/contests`, {
         method: 'POST',
@@ -134,33 +137,35 @@ function ContestPage() {
     <>
       <NavBar />
       <Box sx={{ maxWidth: 800, mx: 'auto', mt: 4 }}>
-        <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', gap: 2, mb: 3 }}>
-          <TextField
-            label="Name"
-            name="name"
-            value={form.name}
-            onChange={handleInputChange}
-            required
-          />
-          <TextField
-            label="Start Time"
-            type="datetime-local"
-            name="startTime"
-            value={form.startTime}
-            onChange={handleInputChange}
-            InputLabelProps={{ shrink: true }}
-            required
-          />
-          <TextField
-            label="Duration (min)"
-            type="number"
-            name="duration"
-            value={form.duration}
-            onChange={handleInputChange}
-            required
-          />
-          <Button type="submit" variant="contained">Schedule</Button>
-        </Box>
+        {isAdmin && (
+          <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', gap: 2, mb: 3 }}>
+            <TextField
+              label="Name"
+              name="name"
+              value={form.name}
+              onChange={handleInputChange}
+              required
+            />
+            <TextField
+              label="Start Time"
+              type="datetime-local"
+              name="startTime"
+              value={form.startTime}
+              onChange={handleInputChange}
+              InputLabelProps={{ shrink: true }}
+              required
+            />
+            <TextField
+              label="Duration (min)"
+              type="number"
+              name="duration"
+              value={form.duration}
+              onChange={handleInputChange}
+              required
+            />
+            <Button type="submit" variant="contained">Schedule</Button>
+          </Box>
+        )}
         <Tabs value={tab} onChange={(e, v) => setTab(v)}>
           <Tab label="Upcoming" />
           <Tab label="Past" />

--- a/codespace/frontend/src/pages/ProblemsPage.js
+++ b/codespace/frontend/src/pages/ProblemsPage.js
@@ -26,6 +26,8 @@ function ProblemsPage() {
   const [topics, setTopics] = useState({});
   const [newTopic, setNewTopic] = useState({ stage: '', name: '' });
   const [newSubtopic, setNewSubtopic] = useState({ stage: '', topic: '', name: '' });
+  const role = localStorage.getItem('role');
+  const isAdmin = role === 'admin' || role === 'superadmin';
 
   useEffect(() => {
     const fetchProblems = async () => {
@@ -81,6 +83,7 @@ function ProblemsPage() {
 
   const addTopic = async (e) => {
     e.preventDefault();
+    if (!isAdmin) return;
     const { stage, name } = newTopic;
     if (!stage || !name) return;
     try {
@@ -98,6 +101,7 @@ function ProblemsPage() {
 
   const addSubtopic = async (e) => {
     e.preventDefault();
+    if (!isAdmin) return;
     const { stage, topic, name } = newSubtopic;
     if (!stage || !topic || !name) return;
     try {
@@ -118,6 +122,7 @@ function ProblemsPage() {
 
   const addProblem = async (e) => {
     e.preventDefault();
+    if (!isAdmin) return;
     try {
       const res = await axios.post(`${BACKEND_URL}/api/problems`, formData);
       setProblems((prev) => [...prev, res.data]);
@@ -150,6 +155,7 @@ function ProblemsPage() {
         </div>
         <div className="problems-content">
           <ProblemSidebar
+            isAdmin={isAdmin}
             showForm={showForm}
             setShowForm={setShowForm}
             showTopicForm={showTopicForm}

--- a/codespace/frontend/src/pages/ResourcesPage.js
+++ b/codespace/frontend/src/pages/ResourcesPage.js
@@ -36,6 +36,8 @@ function ResourcesPage() {
   const [topics, setTopics] = useState({});
   const [newTopic, setNewTopic] = useState({ stage: '', name: '' });
   const [newSubtopic, setNewSubtopic] = useState({ stage: '', topic: '', name: '' });
+  const role = localStorage.getItem('role');
+  const isAdmin = role === 'admin' || role === 'superadmin';
 
   useEffect(() => {
     const fetchResources = async () => {
@@ -91,6 +93,7 @@ function ResourcesPage() {
 
   const addTopic = async (e) => {
     e.preventDefault();
+    if (!isAdmin) return;
     const { stage, name } = newTopic;
     if (!stage || !name) return;
     try {
@@ -108,6 +111,7 @@ function ResourcesPage() {
 
   const addSubtopic = async (e) => {
     e.preventDefault();
+    if (!isAdmin) return;
     const { stage, topic, name } = newSubtopic;
     if (!stage || !topic || !name) return;
     try {
@@ -128,6 +132,7 @@ function ResourcesPage() {
 
   const addResource = async (e) => {
     e.preventDefault();
+    if (!isAdmin) return;
     try {
       const res = await axios.post(`${BACKEND_URL}/api/resources`, formData);
       setResources((prev) => [...prev, res.data]);
@@ -171,6 +176,7 @@ function ResourcesPage() {
         </div>
         <div className="resources-content">
           <ResourcesSidebar
+            isAdmin={isAdmin}
             showForm={showForm}
             setShowForm={setShowForm}
             showTopicForm={showTopicForm}


### PR DESCRIPTION
## Summary
- Hide contest scheduling and problem addition unless role is admin or superadmin
- Suppress problem/resource creation forms for regular users
- Guard server calls with role checks to prevent unauthorized actions

## Testing
- `npm test` (server)
- `CI=true npm test` (frontend) *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*

------
https://chatgpt.com/codex/tasks/task_e_68b5f5ac39348328ab2ae9915a96d2fd