### PR TITLE
Revamp admin role management in dashboard

### DIFF
--- a/codespace/frontend/src/pages/AdminPage.js
+++ b/codespace/frontend/src/pages/AdminPage.js
@@ -33,13 +33,12 @@ const AdminPage = () => {
   }, [role, token]);
 
   const handleRoleChange = (id, newRole) => {
-    if (role !== 'superadmin') return;
-    const endpoint =
-      newRole === 'admin'
-        ? `${BACKEND_URL}/admin/users/${id}/promote`
-        : `${BACKEND_URL}/admin/users/${id}/demote`;
     axios
-      .post(endpoint, {}, { headers: { Authorization: `Bearer ${token}` } })
+      .patch(
+        `${BACKEND_URL}/admin/users/${id}`,
+        { role: newRole },
+        { headers: { Authorization: `Bearer ${token}` } }
+      )
       .then(() => {
         setUsers((prev) =>
           prev.map((u) => (u._id === id ? { ...u, role: newRole } : u))
@@ -64,7 +63,6 @@ const AdminPage = () => {
                 <TableCell>Username</TableCell>
                 <TableCell>Email</TableCell>
                 <TableCell>Role</TableCell>
-                {role === 'superadmin' && <TableCell>Options</TableCell>}
               </TableRow>
             </TableHead>
             <TableBody>
@@ -72,23 +70,23 @@ const AdminPage = () => {
                 <TableRow key={user._id}>
                   <TableCell>{user.username}</TableCell>
                   <TableCell>{user.email}</TableCell>
-                  <TableCell>{user.role}</TableCell>
-                  {role === 'superadmin' && (
-                    <TableCell>
-                      {user.role === 'superadmin' ? (
-                        '—'
-                      ) : (
-                        <Select
-                          size="small"
-                          value={user.role}
-                          onChange={(e) => handleRoleChange(user._id, e.target.value)}
-                        >
-                          <MenuItem value="user">user</MenuItem>
-                          <MenuItem value="admin">admin</MenuItem>
-                        </Select>
-                      )}
-                    </TableCell>
-                  )}
+                  <TableCell>
+                    {(role === 'admin' && user.role === 'superadmin') ? (
+                      user.role
+                    ) : (
+                      <Select
+                        size="small"
+                        value={user.role}
+                        onChange={(e) => handleRoleChange(user._id, e.target.value)}
+                      >
+                        <MenuItem value="user">user</MenuItem>
+                        <MenuItem value="admin">admin</MenuItem>
+                        {role === 'superadmin' && (
+                          <MenuItem value="superadmin">superadmin</MenuItem>
+                        )}
+                      </Select>
+                    )}
+                  </TableCell>
                 </TableRow>
               ))}
             </TableBody>

--- a/codespace/server/routes/admin.js
+++ b/codespace/server/routes/admin.js
@@ -31,4 +31,27 @@ router.post('/users/:id/demote', permit('superadmin'), async (req, res) => {
   res.json({ message: 'User demoted to user' });
 });
 
+// Update a user's role
+router.patch('/users/:id', permit('admin', 'superadmin'), async (req, res) => {
+  const { role } = req.body;
+  if (!role) return res.status(400).json({ message: 'Role is required' });
+
+  const user = await User.findById(req.params.id);
+  if (!user) return res.status(404).json({ message: 'User not found' });
+
+  // Admins can only toggle between user and admin and cannot modify super admins
+  if (req.user.role === 'admin') {
+    if (user.role === 'superadmin') {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+    if (role !== 'user' && role !== 'admin') {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+  }
+
+  user.role = role;
+  await user.save();
+  res.json({ message: 'User role updated' });
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- Allow admins and superadmins to update user roles via unified endpoint
- Replace admin table options column with inline role selector

## Testing
- `npm test` (server)
- `CI=true npm test` (frontend) *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*


------
https://chatgpt.com/codex/tasks/task_e_68b5f92f5368832898fbe6243203ef2c