### PR TITLE
Fix admin user API path

### DIFF
--- a/codespace/frontend/src/pages/AdminPage.js
+++ b/codespace/frontend/src/pages/AdminPage.js
@@ -24,7 +24,7 @@ const AdminPage = () => {
   useEffect(() => {
     if (role === 'admin' || role === 'superadmin') {
       axios
-        .get(`${BACKEND_URL}/admin/users`, {
+        .get(`${BACKEND_URL}/api/admin/users`, {
           headers: { Authorization: `Bearer ${token}` }
         })
         .then((res) => setUsers(res.data))
@@ -35,7 +35,7 @@ const AdminPage = () => {
   const handleRoleChange = (id, newRole) => {
     axios
       .patch(
-        `${BACKEND_URL}/admin/users/${id}`,
+        `${BACKEND_URL}/api/admin/users/${id}`,
         { role: newRole },
         { headers: { Authorization: `Bearer ${token}` } }
       )


### PR DESCRIPTION
## Summary
- fix admin dashboard user fetch by pointing to `/api/admin` routes

## Testing
- `npm test` (backend)
- `npm test -- --watchAll=false` (frontend) *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*

------
https://chatgpt.com/codex/tasks/task_e_68b5fcd0c74c83289fbf55383e726daa