### PR TITLE
Sync room state across users via websockets

### DIFF
--- a/codespace/frontend/src/components/AIChatBox.js
+++ b/codespace/frontend/src/components/AIChatBox.js
@@ -1,45 +1,50 @@
 import React, { useEffect, useRef, useState } from 'react';
-import BACKEND_URL from '../config';
 import '../styles/ChatBox.css';
 import MarkdownMessage from './MarkdownMessage';
 
-export default function AIChatBox({ code }) {
+export default function AIChatBox({ code, socketRef, username }) {
   const [message, setMessage] = useState('');
   const [messages, setMessages] = useState([]);
   const messagesEndRef = useRef(null);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
+    if (!socketRef?.current) return;
+    const handleHistory = (history) => {
+      setMessages(history.map(m => ({
+        self: m.type === 'user' ? m.username === username : false,
+        text: m.text
+      })));
+    };
+    const handleUser = (payload) => {
+      setMessages(prev => [...prev, { self: payload.username === username, text: payload.text }]);
+    };
+    const handleBot = (payload) => {
+      setLoading(false);
+      setMessages(prev => [...prev, { self: false, text: payload.text }]);
+    };
+    socketRef.current.on('ai-chat-history', handleHistory);
+    socketRef.current.on('ai-user-message', handleUser);
+    socketRef.current.on('ai-bot-message', handleBot);
+    socketRef.current.emit('get-ai-messages');
+    return () => {
+      socketRef.current.off('ai-chat-history', handleHistory);
+      socketRef.current.off('ai-user-message', handleUser);
+      socketRef.current.off('ai-bot-message', handleBot);
+    };
+  }, [socketRef, username]);
+
+  useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
-  const send = async (mode) => {
+  const send = (mode) => {
     const prompt = message.trim();
+    if (!socketRef?.current) return;
     if (!prompt && mode === 'normal') return;
-    const payload = { prompt, mode };
-    if (mode !== 'normal') {
-      payload.code = code;
-    }
+    socketRef.current.emit('ai-request', { prompt, mode, code, username });
     setLoading(true);
-    try {
-      const res = await fetch(`${BACKEND_URL}/api/ai/chat`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload)
-      });
-      const data = await res.json();
-      const aiText = data.text || 'No response';
-      setMessages(prev => [
-        ...prev,
-        { self: true, text: prompt || mode },
-        { self: false, text: aiText }
-      ]);
-      setMessage('');
-    } catch (err) {
-      setMessages(prev => [...prev, { self: false, text: 'Error contacting AI' }]);
-    } finally {
-      setLoading(false);
-    }
+    setMessage('');
   };
 
   return (

--- a/codespace/frontend/src/components/Room.js
+++ b/codespace/frontend/src/components/Room.js
@@ -255,7 +255,7 @@ export default function Room() {
               {activeTab === 'general' ? (
                 <ChatBox socket={socket} username={username} />
               ) : (
-                <AIChatBox code={code} />
+                <AIChatBox code={code} socketRef={socketRef} username={username} />
               )}
             </div>
           </aside>


### PR DESCRIPTION
## Summary
- keep per-room code, problem statement, and AI chat history on the server for new joiners
- add websocket-driven AI chat handling for shared assistant messages
- wire AI chat to sockets on the client so all room members see the same conversation

## Testing
- `npm test -- --watchAll=false` (server)
- `CI=true npm test` *(frontend: missing module 'unist-util-visit-parents/do-not-use-color')*


------
https://chatgpt.com/codex/tasks/task_e_68b81ec192a4832887962f96701b1d29