### PR TITLE
Sync code editor in real time

### DIFF
--- a/codespace/frontend/src/components/TextBox.js
+++ b/codespace/frontend/src/components/TextBox.js
@@ -36,12 +36,16 @@ export default function TextBox({socketRef,currentProbId,onCodeChange}) {
     }, [onCodeChange]);
 
     useEffect(() => {
-        if(socketRef.current){
-            socketRef.current.on('receive-code-update', (payload) => {
-                setTextvalue(payload.code);
-            });
-        }
-    },[socketRef]);
+        if (!socketRef.current) return;
+        const handleCodeUpdate = (payload) => {
+            setTextvalue(payload.code);
+            onCodeChange && onCodeChange(payload.code);
+        };
+        socketRef.current.on('receive-code-update', handleCodeUpdate);
+        return () => {
+            socketRef.current.off('receive-code-update', handleCodeUpdate);
+        };
+    }, [socketRef.current, onCodeChange]);
 
 
     useEffect(() => {

--- a/codespace/server/app.js
+++ b/codespace/server/app.js
@@ -131,7 +131,8 @@ io.on('connection', (socket) => {
     socket.on('update-code', (payload) => {
         const state = getRoomState(socket.roomid);
         state.code = payload.code;
-        io.to(socket.roomid).emit('receive-code-update',{code: payload.code});
+        // Broadcast the latest code to everyone else in the room
+        socket.to(socket.roomid).emit('receive-code-update', { code: payload.code });
     });
 
     socket.on('update-problem-statement', (payload) => {


### PR DESCRIPTION
## Summary
- broadcast code updates to other users in a room
- handle incoming code editor updates via socket listener on the client

## Testing
- `npm test` (server)
- `CI=true npm test` *(frontend tests: Cannot find module 'unist-util-visit-parents/do-not-use-color')*


------
https://chatgpt.com/codex/tasks/task_e_68b82cde2950832881173842e8f97fdb