### PR TITLE
style: redesign profile page

### DIFF
--- a/codespace/frontend/src/pages/ProfilePage.js
+++ b/codespace/frontend/src/pages/ProfilePage.js
@@ -1,10 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import NavBar from '../components/NavBar';
 import BACKEND_URL from '../config';
+import defaultAvatar from '../assets/images/user.svg';
+import '../styles/ProfilePage.css';
 
 function ProfilePage() {
   const [submissions, setSubmissions] = useState([]);
   const userId = localStorage.getItem('userid');
+  const username = localStorage.getItem('username');
 
   useEffect(() => {
     async function fetchSubmissions() {
@@ -28,15 +31,52 @@ function ProfilePage() {
   return (
     <div>
       <NavBar />
-      <h1>Profile Page</h1>
-      <ul>
-        {submissions.map((sub) => (
-          <li key={sub._id}>
-            <strong>{sub.problem}</strong>: {sub.verdict} (
-            {new Date(sub.createdAt).toLocaleString()})
-          </li>
-        ))}
-      </ul>
+      <div className="profile-container">
+        <div className="profile-header">
+          <div className="profile-avatar">
+            <img src={defaultAvatar} alt="avatar" />
+          </div>
+          <div className="profile-info">
+            <div className="profile-handle">
+              {username || 'User'}
+              <span className="user-rating">Unrated</span>
+            </div>
+            <div className="profile-stats">
+              <span>Contributions: 0</span>
+              <span>Friends: 0</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="profile-submissions">
+          <h2>Recent Submissions</h2>
+          <table className="submissions-table">
+            <thead>
+              <tr>
+                <th>Problem</th>
+                <th>Verdict</th>
+                <th>Language</th>
+                <th>Time</th>
+              </tr>
+            </thead>
+            <tbody>
+              {submissions.map((sub) => (
+                <tr key={sub._id}>
+                  <td>{sub.problem}</td>
+                  <td className={`verdict ${sub.verdict
+                    .toLowerCase()
+                    .replace(/\s+/g, '-')}`}
+                  >
+                    {sub.verdict}
+                  </td>
+                  <td>{sub.language}</td>
+                  <td>{new Date(sub.createdAt).toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   );
 }

--- a/codespace/frontend/src/styles/ProfilePage.css
+++ b/codespace/frontend/src/styles/ProfilePage.css
@@ -1,0 +1,89 @@
+.profile-container {
+  max-width: 1000px;
+  margin: 20px auto;
+  color: #000;
+}
+
+.profile-header {
+  display: flex;
+  align-items: center;
+  background: #f7f7f7;
+  border: 1px solid #e2e2e2;
+  padding: 20px;
+}
+
+.profile-avatar {
+  width: 150px;
+  height: 150px;
+  border: 1px solid #e2e2e2;
+  margin-right: 20px;
+  background: #fff;
+}
+
+.profile-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.profile-info {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.profile-handle {
+  font-size: 28px;
+  font-weight: bold;
+  color: #0f6ccb;
+}
+
+.user-rating {
+  margin-left: 10px;
+  font-size: 18px;
+  color: #555;
+}
+
+.profile-stats {
+  margin-top: 10px;
+  font-size: 14px;
+  color: #555;
+}
+
+.profile-stats span {
+  margin-right: 20px;
+}
+
+.profile-submissions {
+  margin-top: 30px;
+}
+
+.submissions-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+.submissions-table th,
+.submissions-table td {
+  border: 1px solid #ddd;
+  padding: 8px 10px;
+  text-align: left;
+}
+
+.submissions-table th {
+  background: #f2f2f2;
+}
+
+.verdict.accepted {
+  color: #0a0;
+  font-weight: bold;
+}
+
+.verdict.wrong-answer,
+.verdict.runtime-error,
+.verdict.time-limit-exceeded,
+.verdict.compilation-error {
+  color: #a00;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- add Codeforces-style layout for user profiles
- show avatar, handle, stats, and recent submissions in a table

## Testing
- `npm test -- --watchAll=false` (failed: Must use import to load ES Module: react-markdown)
- `npm test` in `codespace/server`


------
https://chatgpt.com/codex/tasks/task_e_68b83119638c8328a4246faa40feb642