### PR TITLE
feat: show collaborator cursors

### DIFF
--- a/codespace/server/app.js
+++ b/codespace/server/app.js
@@ -153,6 +153,11 @@ io.on('connection', (socket) => {
         socket.to(socket.roomid).emit('receive-language-update',{language: payload.language});
     });
 
+    socket.on('update-cursor', (payload) => {
+        // broadcast cursor position to other users in the room
+        socket.to(socket.roomid).emit('receive-cursor-update', payload);
+    });
+
     socket.on('problem-fetched', (payload) => {
         const state = getRoomState(socket.roomid);
         state.statement = payload.statement;


### PR DESCRIPTION
## Summary
- broadcast cursor updates through socket.io
- display other users' cursors in the editor with color-coded labels

## Testing
- `npm test` (server)
- `npm test -- --watchAll=false` (frontend) *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*


------
https://chatgpt.com/codex/tasks/task_e_68b863f092188328ad40b956800852e1