### PR TITLE
fix: ensure remote cursor updates propagate

### DIFF
--- a/codespace/frontend/src/components/TextBox.js
+++ b/codespace/frontend/src/components/TextBox.js
@@ -104,7 +104,7 @@ export default function TextBox({socketRef,currentProbId,onCodeChange}) {
         return () => {
             socketRef.current.off('receive-input-update', handleInputUpdate);
         };
-    }, [socketRef]);
+    }, [socketRef.current]);
 
     useEffect(() => {
         if (!socketRef.current) return;
@@ -144,7 +144,7 @@ export default function TextBox({socketRef,currentProbId,onCodeChange}) {
             socketRef.current.off('receive-cursor-update', handleCursor);
             socketRef.current.off('users-in-room', handleUsers);
         };
-    }, [socketRef, userid]);
+    }, [socketRef.current, userid]);
 
 
     useEffect(() => {


### PR DESCRIPTION
## Summary
- fix code editor cursor synchronization by reattaching listeners when socket ref connects

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*

------
https://chatgpt.com/codex/tasks/task_e_68b87190b4ec83288cbf9ffd82cded54