### PR TITLE
Verify authentication before showing profile icon

### DIFF
--- a/codespace/frontend/src/components/NavBar.js
+++ b/codespace/frontend/src/components/NavBar.js
@@ -8,6 +8,7 @@ import Logout from '@mui/icons-material/Logout';
 import '../styles/NavBar.css';
 import logo from '../assets/images/logo.svg';
 import userIcon from '../assets/images/user.svg';
+import BACKEND_URL from '../config';
 
 function NavBar() {
   const [loggedIn, setLoggedIn] = useState(false);
@@ -18,8 +19,31 @@ function NavBar() {
 
   useEffect(() => {
     const token = localStorage.getItem('token');
-    setLoggedIn(!!token);
-    setRole(localStorage.getItem("role"));
+    if (!token) {
+      setLoggedIn(false);
+      setRole(null);
+      return;
+    }
+
+    fetch(`${BACKEND_URL}/api/auth/verify`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error('Not authenticated');
+        return res.json();
+      })
+      .then((data) => {
+        setLoggedIn(true);
+        setRole(data.role);
+      })
+      .catch(() => {
+        localStorage.removeItem('token');
+        localStorage.removeItem('role');
+        setLoggedIn(false);
+        setRole(null);
+      });
   }, []);
 
   const handleMenu = (event) => {

--- a/codespace/frontend/src/pages/ProfilePage.js
+++ b/codespace/frontend/src/pages/ProfilePage.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import NavBar from '../components/NavBar';
 import BACKEND_URL from '../config';
 import defaultAvatar from '../assets/images/user.svg';
@@ -8,11 +9,16 @@ function ProfilePage() {
   const [submissions, setSubmissions] = useState([]);
   const userId = localStorage.getItem('userid');
   const username = localStorage.getItem('username');
+  const navigate = useNavigate();
 
   useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      navigate('/login');
+      return;
+    }
+
     async function fetchSubmissions() {
-      const token = localStorage.getItem('token');
-      if (!userId || !token) return;
       try {
         const res = await fetch(`${BACKEND_URL}/api/users/${userId}/submissions`, {
           headers: { Authorization: `Bearer ${token}` },
@@ -25,8 +31,10 @@ function ProfilePage() {
         console.error('Failed to fetch submissions', err);
       }
     }
-    fetchSubmissions();
-  }, [userId]);
+    if (userId) {
+      fetchSubmissions();
+    }
+  }, [userId, navigate]);
 
   return (
     <div>

--- a/codespace/server/routes/auth.js
+++ b/codespace/server/routes/auth.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const User = require('../model/userModel');
+const authMiddleware = require('../middleware/authMiddleware');
 
 const router = express.Router();
 const url = process.env.MONGODB_URI || 'mongodb://localhost:27017/graduation_project';
@@ -48,6 +49,10 @@ router.post('/login', async (req, res) => {
   } catch (err) {
     res.status(500).json({ message: 'Server error' });
   }
+});
+
+router.get('/verify', authMiddleware, (req, res) => {
+  res.json({ id: req.user.id, username: req.user.username, role: req.user.role });
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- Validate stored tokens with new `/api/auth/verify` endpoint before rendering the profile icon in the nav bar
- Redirect to login if unauthenticated while accessing the profile page
- Add server-side endpoint to verify JWTs and return user data

## Testing
- `npm test -- --watchAll=false` *(failed: Cannot find module 'unist-util-visit-parents/do-not-use-color')*
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8c3d467248328aebbdec5c80a4df6