### PR TITLE
Disconnect socket on tab close

### DIFF
--- a/codespace/frontend/src/components/Room.js
+++ b/codespace/frontend/src/components/Room.js
@@ -86,6 +86,20 @@ export default function Room() {
     // TODO: get the username
     // TODO: we join room here
 
+    useEffect(() => {
+      const handleUnload = () => {
+        if (socketRef.current) {
+          socketRef.current.disconnect();
+        }
+      };
+      window.addEventListener('beforeunload', handleUnload);
+      window.addEventListener('offline', handleUnload);
+      return () => {
+        window.removeEventListener('beforeunload', handleUnload);
+        window.removeEventListener('offline', handleUnload);
+      };
+    }, []);
+
     const toggleMic = () => {
       if (isMicOn) {
         // turn off mic


### PR DESCRIPTION
## Summary
- Disconnect room socket when the browser unloads or goes offline to clear server room membership

## Testing
- `npm test --silent` (server)
- `npm test --silent -- --watchAll=false` (frontend) *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*

------
https://chatgpt.com/codex/tasks/task_e_68b8c5f8bdd08328ad7f536fe1900fbd