### PR TITLE
feat: enhance profile with activity heatmap and editing

### DIFF
--- a/codespace/frontend/package.json
+++ b/codespace/frontend/package.json
@@ -31,7 +31,8 @@
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^15.6.6",
     "remark-gfm": "^4.0.1",
-    "rehype-sanitize": "^6.0.0"
+    "rehype-sanitize": "^6.0.0",
+    "react-calendar-heatmap": "^1.8.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/codespace/frontend/src/pages/ProfilePage.js
+++ b/codespace/frontend/src/pages/ProfilePage.js
@@ -3,12 +3,17 @@ import { useNavigate } from 'react-router-dom';
 import NavBar from '../components/NavBar';
 import BACKEND_URL from '../config';
 import defaultAvatar from '../assets/images/user.svg';
+import CalendarHeatmap from 'react-calendar-heatmap';
+import 'react-calendar-heatmap/dist/styles.css';
 import '../styles/ProfilePage.css';
 
 function ProfilePage() {
   const [submissions, setSubmissions] = useState([]);
+  const [userInfo, setUserInfo] = useState({ username: '', displayName: '', friends: [] });
+  const [showEdit, setShowEdit] = useState(false);
+  const [showFriends, setShowFriends] = useState(false);
+  const [form, setForm] = useState({ username: '', displayName: '', password: '' });
   const userId = localStorage.getItem('userid');
-  const username = localStorage.getItem('username');
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -31,10 +36,56 @@ function ProfilePage() {
         console.error('Failed to fetch submissions', err);
       }
     }
+    async function fetchUser() {
+      try {
+        const res = await fetch(`${BACKEND_URL}/api/users/${userId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setUserInfo(data);
+          setForm({ username: data.username || '', displayName: data.displayName || '', password: '' });
+        }
+      } catch (err) {
+        console.error('Failed to fetch user', err);
+      }
+    }
     if (userId) {
       fetchSubmissions();
+      fetchUser();
     }
   }, [userId, navigate]);
+
+  const handleSave = async (e) => {
+    e.preventDefault();
+    const token = localStorage.getItem('token');
+    try {
+      const res = await fetch(`${BACKEND_URL}/api/users/${userId}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(form),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setUserInfo((prev) => ({ ...prev, username: data.username, displayName: data.displayName }));
+        localStorage.setItem('username', data.username);
+        setShowEdit(false);
+        setForm((prev) => ({ ...prev, password: '' }));
+      }
+    } catch (err) {
+      console.error('Failed to update profile', err);
+    }
+  };
+
+  const heatmapCounts = submissions.reduce((acc, sub) => {
+    const date = new Date(sub.createdAt).toISOString().split('T')[0];
+    acc[date] = (acc[date] || 0) + 1;
+    return acc;
+  }, {});
+  const heatmapValues = Object.keys(heatmapCounts).map((date) => ({ date, count: heatmapCounts[date] }));
 
   return (
     <div>
@@ -46,14 +97,69 @@ function ProfilePage() {
           </div>
           <div className="profile-info">
             <div className="profile-handle">
-              {username || 'User'}
+              {userInfo.displayName || userInfo.username || 'User'}
               <span className="user-rating">Unrated</span>
             </div>
             <div className="profile-stats">
-              <span>Contributions: 0</span>
-              <span>Friends: 0</span>
+              <span>Contributions: {submissions.length}</span>
+              <span className="friends-link" onClick={() => setShowFriends(!showFriends)}>
+                Friends: {userInfo.friends ? userInfo.friends.length : 0}
+              </span>
+              <button className="edit-button" onClick={() => setShowEdit(!showEdit)}>Edit Profile</button>
             </div>
           </div>
+        </div>
+
+        {showFriends && (
+          <div className="friends-list">
+            <h3>Friends</h3>
+            <ul>
+              {(userInfo.friends || []).map((f) => (
+                <li key={f._id}>{f.displayName || f.username}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {showEdit && (
+          <form className="edit-form" onSubmit={handleSave}>
+            <input
+              type="text"
+              value={form.username}
+              onChange={(e) => setForm({ ...form, username: e.target.value })}
+              placeholder="Username"
+              required
+            />
+            <input
+              type="text"
+              value={form.displayName}
+              onChange={(e) => setForm({ ...form, displayName: e.target.value })}
+              placeholder="Display Name"
+            />
+            <input
+              type="password"
+              value={form.password}
+              onChange={(e) => setForm({ ...form, password: e.target.value })}
+              placeholder="New Password"
+            />
+            <button type="submit">Save</button>
+          </form>
+        )}
+
+        <div className="profile-heatmap">
+          <h2>Submission Activity</h2>
+          <CalendarHeatmap
+            startDate={new Date(new Date().getFullYear(), 0, 1)}
+            endDate={new Date(new Date().getFullYear(), 11, 31)}
+            values={heatmapValues}
+            classForValue={(value) => {
+              if (!value || !value.count) {
+                return 'color-empty';
+              }
+              return `color-scale-${Math.min(value.count, 4)}`;
+            }}
+            tooltipDataAttrs={(value) => ({ title: `${value.date}: ${value.count || 0} submissions` })}
+          />
         </div>
 
         <div className="profile-submissions">

--- a/codespace/frontend/src/styles/ProfilePage.css
+++ b/codespace/frontend/src/styles/ProfilePage.css
@@ -54,6 +54,61 @@
   margin-right: 20px;
 }
 
+.edit-button {
+  margin-left: 10px;
+  padding: 5px 10px;
+  cursor: pointer;
+}
+
+.friends-link {
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.friends-list {
+  margin-top: 20px;
+}
+
+.edit-form {
+  margin-top: 20px;
+}
+
+.edit-form input {
+  display: block;
+  margin-bottom: 10px;
+  padding: 8px;
+  width: 100%;
+  max-width: 300px;
+}
+
+.edit-form button {
+  padding: 8px 16px;
+}
+
+.profile-heatmap {
+  margin-top: 30px;
+}
+
+.react-calendar-heatmap .color-empty {
+  fill: #eeeeee;
+}
+
+.react-calendar-heatmap .color-scale-1 {
+  fill: #c6e48b;
+}
+
+.react-calendar-heatmap .color-scale-2 {
+  fill: #7bc96f;
+}
+
+.react-calendar-heatmap .color-scale-3 {
+  fill: #239a3b;
+}
+
+.react-calendar-heatmap .color-scale-4 {
+  fill: #196127;
+}
+
 .profile-submissions {
   margin-top: 30px;
 }

--- a/codespace/server/model/userModel.js
+++ b/codespace/server/model/userModel.js
@@ -4,7 +4,9 @@ const userSchema = new mongoose.Schema({
   username: { type: String, required: true, unique: true },
   email: { type: String, required: true, unique: true },
   password: { type: String, required: true },
-  role: { type: String, enum: ['user','admin','superadmin'], default: 'user' }
+  role: { type: String, enum: ['user','admin','superadmin'], default: 'user' },
+  displayName: { type: String },
+  friends: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }]
 });
 
 module.exports = mongoose.model('User', userSchema);

--- a/codespace/server/routes/auth.js
+++ b/codespace/server/routes/auth.js
@@ -11,14 +11,20 @@ const url = process.env.MONGODB_URI || 'mongodb://localhost:27017/graduation_pro
 mongoose.connect(url);
 
 router.post('/register', async (req, res) => {
-  const { username, email, password, role } = req.body;
+  const { username, email, password, role, displayName } = req.body;
   try {
     const existing = await User.findOne({ $or: [{ username }, { email }] });
     if (existing) {
       return res.status(400).json({ message: 'User already exists' });
     }
     const hashed = await bcrypt.hash(password, 10);
-    const user = new User({ username, email, password: hashed, role: role || 'user' });
+    const user = new User({
+      username,
+      email,
+      password: hashed,
+      role: role || 'user',
+      displayName: displayName || username,
+    });
     await user.save();
     res.json({ message: 'User created' });
   } catch (err) {

--- a/codespace/server/routes/users.js
+++ b/codespace/server/routes/users.js
@@ -1,7 +1,9 @@
 const express = require('express');
 const mongoose = require('mongoose');
 const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
 const Submission = require('../model/submissionModel');
+const User = require('../model/userModel');
 
 const router = express.Router();
 const url = process.env.MONGODB_URI || 'mongodb://localhost:27017/graduation_project';
@@ -30,6 +32,65 @@ router.get('/:id/submissions', authenticate, async (req, res) => {
   try {
     const submissions = await Submission.find({ user: id }).sort({ createdAt: -1 });
     res.json(submissions);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.get('/:id/friends', authenticate, async (req, res) => {
+  const { id } = req.params;
+  if (req.user.id !== id) {
+    return res.status(403).json({ message: 'Forbidden' });
+  }
+  try {
+    const user = await User.findById(id).populate('friends', 'username displayName');
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+    res.json(user.friends);
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.get('/:id', authenticate, async (req, res) => {
+  const { id } = req.params;
+  if (req.user.id !== id) {
+    return res.status(403).json({ message: 'Forbidden' });
+  }
+  try {
+    const user = await User.findById(id).populate('friends', 'username displayName');
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+    res.json({
+      username: user.username,
+      displayName: user.displayName,
+      friends: user.friends,
+    });
+  } catch (err) {
+    res.status(500).json({ message: 'Server error' });
+  }
+});
+
+router.put('/:id', authenticate, async (req, res) => {
+  const { id } = req.params;
+  if (req.user.id !== id) {
+    return res.status(403).json({ message: 'Forbidden' });
+  }
+  const { username, displayName, password } = req.body;
+  const update = {};
+  if (username) update.username = username;
+  if (typeof displayName !== 'undefined') update.displayName = displayName;
+  if (password) {
+    update.password = await bcrypt.hash(password, 10);
+  }
+  try {
+    const user = await User.findByIdAndUpdate(id, update, { new: true });
+    if (!user) {
+      return res.status(404).json({ message: 'User not found' });
+    }
+    res.json({ username: user.username, displayName: user.displayName });
   } catch (err) {
     res.status(500).json({ message: 'Server error' });
   }


### PR DESCRIPTION
## Summary
- add displayName and friends to user model with update and fetch endpoints
- allow profile editing of username, display name and password
- show contribution heatmap and friends list on profile page

## Testing
- `npm test` (server)
- `npm test` (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68b961263ce483289a638d25ceb0ca78