### PR TITLE
Add navbar user search with friend toggling

### DIFF
--- a/codespace/frontend/src/styles/NavBar.css
+++ b/codespace/frontend/src/styles/NavBar.css
@@ -9,6 +9,44 @@
   color: #fff;
 }
 
+.navbar-search {
+  flex: 1;
+  text-align: center;
+  position: relative;
+}
+
+.navbar-search input {
+  width: 60%;
+  padding: 0.3rem 0.5rem;
+  border: none;
+  border-radius: 4px;
+}
+
+.navbar-search-results {
+  position: absolute;
+  top: 110%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #fff;
+  color: #000;
+  max-height: 200px;
+  overflow-y: auto;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+}
+
+.navbar-search-results table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.navbar-search-results th,
+.navbar-search-results td {
+  padding: 0.5rem;
+  text-align: left;
+}
+
 .navbar-brand .brand-link {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add username search to navbar with ability to add or remove friends
- expose backend endpoints for searching users and toggling friend status
- style search dropdown and results table

## Testing
- `cd codespace/server && npm test`
- `cd ../frontend && npm test -- --watchAll=false` *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*

------
https://chatgpt.com/codex/tasks/task_e_68b965db3c5c83289fcecaa323b3dea6