### PR TITLE
feat: integrate cf-tool submission

### DIFF
--- a/codespace/frontend/src/components/TextBox.js
+++ b/codespace/frontend/src/components/TextBox.js
@@ -12,7 +12,7 @@ import { RangeSetBuilder } from '@codemirror/state';
 
 // Replace with the URL you want to send the request to
 const apiUrl = `${BACKEND_URL}/test`; // compilation sandbox endpoint
-const submitUrl = `${BACKEND_URL}/submit`;
+const submitUrl = `${BACKEND_URL}/cf/submit`;
 
 const defaultCpp = "#include <bits/stdc++.h>\nusing namespace std;\n\nint main(){\n int t;\n cin >> t;\n while(t--){\n\n }\n}";
 const defaultPython = `import sys\n\n\ndef solve():\n    pass\n\n\ndef main():\n    t = int(sys.stdin.readline())\n    for _ in range(t):\n        solve()\n\n\nif __name__ == "__main__":\n    main()\n`;

--- a/codespace/server/app.js
+++ b/codespace/server/app.js
@@ -6,6 +6,7 @@ const cors = require('cors');
 const fetch = require('node-fetch');
 const codeRunner = require("./routes/codeRunner")
 const submit = require("./routes/submit")
+const codeforces = require("./routes/codeforces")
 const api1 = require("./routes/api")
 const auth = require("./routes/auth")
 const roomsRoute = require("./routes/rooms");
@@ -52,6 +53,7 @@ app.use('/api/problems', problemsRoute)
 app.use('/api/ai', aiRoute)
 app.use('/test',codeRunner)
 app.use('/submit',submit)
+app.use('/cf', codeforces)
 
 app.get('/', (req, res) => {
     res.send('omg hewwo fren!!');

--- a/codespace/server/jobs/webScrapingWorker.js
+++ b/codespace/server/jobs/webScrapingWorker.js
@@ -36,6 +36,7 @@ async function scrapingWorker(job) {
             }
             try {
                 const parsedOutput = JSON.parse(stdout);
+                parsedOutput.id = req_problem;
                 if (redisClient.isOpen) {
                     redisClient.setEx(req_problem, 60000, JSON.stringify(parsedOutput));
                 }

--- a/codespace/server/routes/api.js
+++ b/codespace/server/routes/api.js
@@ -166,7 +166,11 @@ router.get('/parse_problem/:param',async (req,res) => {
   }
   console.log(data);
   if(data!==null){
-    res.json(JSON.parse(data));
+    const parsed = JSON.parse(data);
+    if (!parsed.id) {
+      parsed.id = req_problem;
+    }
+    res.json(parsed);
   }
   else{
     // let the worker do it!!
@@ -174,6 +178,7 @@ router.get('/parse_problem/:param',async (req,res) => {
     console.log("added to queue");
     try{
       const result = await waitforJobCompletion(scrapingQueue,job);
+      result.id = req_problem;
       res.json(result);
     }
     catch(err){

--- a/codespace/server/routes/codeforces.js
+++ b/codespace/server/routes/codeforces.js
@@ -1,0 +1,73 @@
+const express = require('express');
+const mongoose = require('mongoose');
+const jwt = require('jsonwebtoken');
+const { exec } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const Submission = require('../model/submissionModel');
+
+const router = express.Router();
+
+const url = process.env.MONGODB_URI || 'mongodb://localhost:27017/graduation_project';
+mongoose.connect(url);
+
+function authenticate(req, res, next) {
+  const authHeader = req.headers['authorization'];
+  const token = authHeader && authHeader.split(' ')[1];
+  if (!token) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'changeme');
+    req.user = decoded;
+    next();
+  } catch (err) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+}
+
+router.post('/submit', authenticate, async (req, res) => {
+  const { code, problem_id, language = 'cpp' } = req.body;
+  if (!code || !problem_id) {
+    return res.status(400).send('Code and problem ID are required.');
+  }
+
+  const langMap = { cpp: '54', python: '31', java: '36' };
+  const extMap = { cpp: 'cpp', python: 'py', java: 'java' };
+  const langId = langMap[language] || langMap.cpp;
+  const ext = extMap[language] || 'cpp';
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cf-'));
+  const filePath = path.join(tmpDir, `Main.${ext}`);
+  fs.writeFileSync(filePath, code);
+
+  const cmd = `cf submit ${problem_id} ${filePath} --lang ${langId} --wait`;
+
+  exec(cmd, (error, stdout, stderr) => {
+    const output = stdout.toString() + stderr.toString();
+    if (error) {
+      console.error('cf-tool error:', output);
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      return res.status(500).send('Submission failed');
+    }
+
+    const verdictMatch = output.match(/(Accepted|Wrong answer|Time limit exceeded|Compilation error|Runtime error)/i);
+    const verdict = verdictMatch ? verdictMatch[1] : 'Unknown';
+
+    const submission = new Submission({
+      user: req.user.id,
+      problem: problem_id,
+      code,
+      verdict,
+      language,
+    });
+    submission.save().catch((err) => console.error('Failed to save submission:', err));
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    res.send(verdict);
+  });
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add Codeforces submission endpoint that wraps cf-tool and records user submissions
- return scraped problem IDs and cache them in worker
- wire frontend submit button to new backend endpoint

## Testing
- `cd codespace/server && npm test`
- `cd codespace/frontend && CI=true npm test -- --watchAll=false` *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*

------
https://chatgpt.com/codex/tasks/task_e_68be13f83c5c83289b98ac567a7c9d1d