### PR TITLE
Differentiate inline code styling and enhance problem buttons

### DIFF
--- a/codespace/frontend/src/components/AIChatBox.js
+++ b/codespace/frontend/src/components/AIChatBox.js
@@ -54,7 +54,8 @@ export default function AIChatBox({ code, socketRef, username }) {
   }, [messages]);
 
   const send = (mode) => {
-    const prompt = message.trim();
+    const trimmed = message.trim();
+    const prompt = trimmed || (mode !== 'normal' ? mode : '');
     if (!socketRef?.current) return;
     if (!prompt && mode === 'normal') return;
     socketRef.current.emit('ai-request', { prompt, mode, code, username });

--- a/codespace/frontend/src/components/Room.js
+++ b/codespace/frontend/src/components/Room.js
@@ -294,10 +294,18 @@ export default function Room() {
                 />
               ) : (
                 <div className='problem-options'>
-                  <button className='view-problem-button' onClick={handleFetchClick}>
+                  <button
+                    className='view-problem-button'
+                    onClick={handleFetchClick}
+                    title='Fetch a problem from Codeforces'
+                  >
                     Fetch from Codeforces
                   </button>
-                  <button className='view-problem-button' onClick={handleWriteClick}>
+                  <button
+                    className='view-problem-button'
+                    onClick={handleWriteClick}
+                    title='Create and share your own problem'
+                  >
                     Write a Problem
                   </button>
                 </div>

--- a/codespace/frontend/src/styles/ChatBox.css
+++ b/codespace/frontend/src/styles/ChatBox.css
@@ -78,6 +78,14 @@
   overflow-x: auto;
 }
 
+/* Inline code segments rendered with single backticks */
+.chat-text code {
+  background: #f0f0f0;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+  font-family: monospace;
+}
+
 .code-block {
   position: relative;
 }

--- a/codespace/frontend/src/styles/RoomPage.css
+++ b/codespace/frontend/src/styles/RoomPage.css
@@ -95,26 +95,29 @@
 }
 
 .view-problem-button {
-  margin-bottom: 1rem;
-  padding: 0.5rem 1rem;
+  padding: 1rem 2rem;
   background: #1976d2;
   color: #fff;
   border: none;
   border-radius: 6px;
   cursor: pointer;
-  transition: background 0.3s ease;
+  font-size: 1rem;
+  min-width: 180px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: background 0.3s ease, transform 0.2s ease;
 }
 
 .view-problem-button:hover {
   background: #115293;
+  transform: scale(1.05);
 }
 
 .problem-options {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
   justify-content: center;
-  gap: 1rem;
+  gap: 1.5rem;
   min-height: 200px;
 }
 


### PR DESCRIPTION
## Summary
- Ensure AI chat's inline code uses a distinct style from fenced blocks
- Default "fix" and "explain" prompts avoid empty user messages
- Redesign problem fetch/create buttons with horizontal layout, hover effects, and tooltips

## Testing
- `CI=true npm test` *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*

------
https://chatgpt.com/codex/tasks/task_e_68bec229b43c8328954baa8248df292f