### PR TITLE
Handle custom problem submissions without ID

### DIFF
--- a/codespace/frontend/src/components/Room.js
+++ b/codespace/frontend/src/components/Room.js
@@ -304,7 +304,12 @@ export default function Room() {
               )}
             </div>
             <div className='editor-container'>
-              <TextBox socketRef={socketRef} currentProbId={currentProbId} onCodeChange={setCode} />
+              <TextBox
+                socketRef={socketRef}
+                currentProbId={currentProbId}
+                tests={tests}
+                onCodeChange={setCode}
+              />
             </div>
           </div>
         </div>

--- a/codespace/frontend/src/components/TextBox.js
+++ b/codespace/frontend/src/components/TextBox.js
@@ -61,7 +61,7 @@ class CursorWidget extends WidgetType {
         return span;
     }
 }
-export default function TextBox({socketRef,currentProbId,onCodeChange}) {
+export default function TextBox({socketRef,currentProbId,tests,onCodeChange}) {
     console.log('I am textbox and the current problem id is ' + currentProbId);
     const [language, setLanguage] = useState('cpp');
     const [textvalue, setTextvalue] = useState(defaultCpp);
@@ -212,9 +212,17 @@ export default function TextBox({socketRef,currentProbId,onCodeChange}) {
         try{
             const requestData = {
                 code: textvalue,
-                problem_id: currentProbId,
                 language: language
             };
+            if (currentProbId) {
+                requestData.problem_id = currentProbId;
+            } else if (tests && tests.length > 0) {
+                requestData.tests = tests;
+            } else {
+                setOutputvalue('No tests found');
+                setColor('red');
+                return;
+            }
             const token = localStorage.getItem('token');
             const response = await axios.post(submitUrl, requestData, {
                 headers: { Authorization: `Bearer ${token}` }


### PR DESCRIPTION
## Summary
- allow submit API to accept direct AI testcases when no problem ID is supplied
- run provided tests in submission worker or fetch by problem ID
- send AI generated tests from client and show "No tests found" when missing

## Testing
- `npm test`
- `CI=true npm test -- --watchAll=false` *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*

------
https://chatgpt.com/codex/tasks/task_e_68bec2e1aab88328a90e048457b5afd3