### PR TITLE
Fix rendering for single-word code in AI responses

### DIFF
--- a/codespace/frontend/src/components/MarkdownMessage.js
+++ b/codespace/frontend/src/components/MarkdownMessage.js
@@ -20,14 +20,18 @@ const schema = {
 
 function Code({ inline, className, children, ...props }) {
   const match = /language-(\w+)/.exec(className || '');
-  const code = String(children).replace(/\n$/, '');
+  const rawCode = String(children);
+  const code = rawCode.replace(/\n$/, '');
   const handleCopy = () => {
     navigator.clipboard.writeText(code);
   };
-  if (inline) {
+  // Sometimes the AI returns fenced blocks wrapping single words like `n`.
+  // Such blocks have no newlines and no language class. Treat them as inline
+  // code so they render correctly within the sentence instead of as a block.
+  if (inline || (!rawCode.includes('\n') && !className)) {
     return (
       <code className={className} {...props}>
-        {children}
+        {code}
       </code>
     );
   }

--- a/codespace/frontend/src/components/__tests__/MarkdownMessage.test.js
+++ b/codespace/frontend/src/components/__tests__/MarkdownMessage.test.js
@@ -34,5 +34,13 @@ describe('MarkdownMessage', () => {
     render(<MarkdownMessage content={md} />);
     expect(screen.queryByRole('img')).toBeNull();
   });
+
+  test('renders single-word fenced blocks as inline code', () => {
+    const md = 'Number of items:\n```n```';
+    render(<MarkdownMessage content={md} />);
+    // It should render `n` inside a code element but without copy button
+    expect(screen.getByText('n', { selector: 'code' })).toBeInTheDocument();
+    expect(screen.queryByLabelText(/copy code/i)).toBeNull();
+  });
 });
 


### PR DESCRIPTION
## Summary
- Treat fenced blocks without newlines and language as inline code to avoid stray code blocks
- Add regression test ensuring single-word fenced blocks render inline

## Testing
- `CI=true npm test --silent` *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*

------
https://chatgpt.com/codex/tasks/task_e_68bec5dfa8ec8328846a96635afbbb66