### PR TITLE
Persist room state and add clear controls

### DIFF
--- a/codespace/frontend/src/components/AIChatBox.js
+++ b/codespace/frontend/src/components/AIChatBox.js
@@ -38,14 +38,17 @@ export default function AIChatBox({ code, socketRef, username }) {
         { self: false, text: payload.text, sender: 'bot' },
       ]);
     };
+    const handleClear = () => setMessages([]);
     socketRef.current.on('ai-chat-history', handleHistory);
     socketRef.current.on('ai-user-message', handleUser);
     socketRef.current.on('ai-bot-message', handleBot);
+    socketRef.current.on('ai-chat-cleared', handleClear);
     socketRef.current.emit('get-ai-messages');
     return () => {
       socketRef.current.off('ai-chat-history', handleHistory);
       socketRef.current.off('ai-user-message', handleUser);
       socketRef.current.off('ai-bot-message', handleBot);
+      socketRef.current.off('ai-chat-cleared', handleClear);
     };
   }, [socketRef, username]);
 
@@ -109,6 +112,7 @@ export default function AIChatBox({ code, socketRef, username }) {
           onChange={(e) => setMessage(e.target.value)}
         />
         <div className="chat-actions">
+          <button type="button" onClick={() => socketRef?.current?.emit('clear-ai-chat')} disabled={loading}>Clear</button>
           <button type="button" onClick={() => send('normal')} disabled={loading}>Send</button>
           <button type="button" onClick={() => send('fix')} disabled={loading}>Fix</button>
           <button type="button" onClick={() => send('explain')} disabled={loading}>Explain</button>

--- a/codespace/frontend/src/components/ChatBox.js
+++ b/codespace/frontend/src/components/ChatBox.js
@@ -33,6 +33,13 @@ export default function ChatBox({ socket, username }) {
     return () => socket.off('room-messages', handler);
   }, [socket]);
 
+  useEffect(() => {
+    if (!socket) return;
+    const handleClear = () => setMessages([]);
+    socket.on('messages-cleared', handleClear);
+    return () => socket.off('messages-cleared', handleClear);
+  }, [socket]);
+
   // Always scroll to bottom when messages change
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -87,6 +94,7 @@ export default function ChatBox({ socket, username }) {
           onChange={(e) => setMessage(e.target.value)}
         />
         <div className="chat-actions">
+          <button type="button" onClick={() => socket?.emit('clear-messages')}>Clear</button>
           <button type="submit">Send</button>
         </div>
       </form>

--- a/codespace/frontend/src/components/Room.js
+++ b/codespace/frontend/src/components/Room.js
@@ -83,6 +83,15 @@ export default function Room() {
 
     const handleFetchClick = () => setFetchOpen(true);
     const handleWriteClick = () => setCustomOpen(true);
+    const clearProblem = () => {
+      setProblemStatement('');
+      setSampleInput('');
+      setSampleOutput('');
+      setTests([]);
+      setShowProblem(false);
+      setCurrentProb(null);
+      socketRef.current?.emit('clear-problem');
+    };
     const userVideo = useRef();
     const socketRef = useRef();
     const [socket, setSocket] = useState(null);
@@ -206,6 +215,14 @@ export default function Room() {
         setShowProblem(true);
       });
 
+      socketRef.current.on('problem-cleared', () => {
+        setProblemStatement('');
+        setSampleInput('');
+        setSampleOutput('');
+        setTests([]);
+        setShowProblem(false);
+      });
+
       socketRef.current.emit('join room', { roomid: roomid, userid: userid, username: username });
       socketRef.current.emit('get-users-in-room');
 
@@ -285,13 +302,16 @@ export default function Room() {
           <div className='room-main'>
             <div className='problem-view' style={{position: "relative", paddingLeft:"30px", marginTop: "40px"}}>
               {showProblem ? (
-                <MainLHS
-                  currentProbId={currentProbId}
-                  setCurrentProb={setCurrentProb}
-                  externalInput={problemStatement}
-                  externalSampleInput={sampleInput}
-                  externalSampleOutput={sampleOutput}
-                />
+                <>
+                  <button className='view-problem-button' onClick={clearProblem}>Clear Problem</button>
+                  <MainLHS
+                    currentProbId={currentProbId}
+                    setCurrentProb={setCurrentProb}
+                    externalInput={problemStatement}
+                    externalSampleInput={sampleInput}
+                    externalSampleOutput={sampleOutput}
+                  />
+                </>
               ) : (
                 <div className='problem-options'>
                   <button


### PR DESCRIPTION
## Summary
- Preserve room data on the server when all users disconnect
- Add clear actions for chat, AI chat, and problem including generated tests
- Expose clear controls in Room UI and corresponding socket events

## Testing
- `cd codespace/server && npm test`
- `cd codespace/frontend && npm test -- --watchAll=false` *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*

------
https://chatgpt.com/codex/tasks/task_e_68bec65d15e083289e32c1ec0f9812f6