### PR TITLE
fix: remove code block background styling

### DIFF
--- a/codespace/frontend/src/styles/ChatBox.css
+++ b/codespace/frontend/src/styles/ChatBox.css
@@ -72,7 +72,6 @@
 }
 
 .chat-text pre {
-  background: #f0f0f0;
   padding: 0.5rem;
   border-radius: 4px;
   overflow-x: auto;


### PR DESCRIPTION
## Summary
- prevent chat code blocks from inheriting gray background so only inline code is highlighted

## Testing
- `cd codespace/frontend && npm test -- --watchAll=false` *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*


------
https://chatgpt.com/codex/tasks/task_e_68bedf12f9b0832888d519b56cde8f6f