### PR TITLE
fix: handle JSON test parsing

### DIFF
--- a/codespace/server/routes/ai.js
+++ b/codespace/server/routes/ai.js
@@ -80,9 +80,16 @@ router.post('/generate-tests', async (req, res) => {
       : '[]';
     let tests = [];
     try {
-      tests = JSON.parse(aiText);
+      // Some responses may include additional text or code fences around the
+      // JSON array. Extract the first JSON array substring and parse that.
+      const match = aiText.match(/\[[\s\S]*\]/);
+      if (match) {
+        tests = JSON.parse(match[0]);
+      } else {
+        console.error('No JSON array found in AI response');
+      }
     } catch (e) {
-      console.error('Failed to parse tests from AI');
+      console.error('Failed to parse tests from AI', e);
     }
     res.json({ tests });
   } catch (err) {


### PR DESCRIPTION
## Summary
- make test generation more robust by extracting the first JSON array and parsing it

## Testing
- `cd codespace/server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bee948f5d48328a24a114fb35ddd3f