### PR TITLE
Enable viewing friend profiles with submissions

### DIFF
--- a/codespace/frontend/src/App.js
+++ b/codespace/frontend/src/App.js
@@ -12,6 +12,7 @@ import ResourcesPage from './pages/ResourcesPage';
 import SectionsPage from './pages/SectionsPage';
 import ContactPage from './pages/ContactPage';
 import ProfilePage from './pages/ProfilePage';
+import FriendProfilePage from './pages/FriendProfilePage';
 import AdminPage from './pages/AdminPage';
 import MarkdownTestPage from './pages/MarkdownTestPage';
 
@@ -30,6 +31,7 @@ function App(){
         <Route path="/rooms" element={<RoomsPage />} />
         <Route path="/contact" element={<ContactPage />} />
         <Route path="/profile" element={<ProfilePage />} />
+        <Route path="/profile/:id" element={<FriendProfilePage />} />
         <Route path="/room" element={<Room />} />
         <Route path="/admin" element={<AdminPage />} />
         <Route path="/markdown-test" element={<MarkdownTestPage />} />

--- a/codespace/frontend/src/pages/FriendProfilePage.js
+++ b/codespace/frontend/src/pages/FriendProfilePage.js
@@ -1,0 +1,118 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import NavBar from '../components/NavBar';
+import BACKEND_URL from '../config';
+import defaultAvatar from '../assets/images/user.svg';
+import CalendarHeatmap from 'react-calendar-heatmap';
+import 'react-calendar-heatmap/dist/styles.css';
+import '../styles/ProfilePage.css';
+
+function FriendProfilePage() {
+  const { id } = useParams();
+  const [submissions, setSubmissions] = useState([]);
+  const [userInfo, setUserInfo] = useState({ username: '', displayName: '', friends: [] });
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) {
+      navigate('/login');
+      return;
+    }
+    async function fetchData() {
+      try {
+        const userRes = await fetch(`${BACKEND_URL}/api/users/${id}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (userRes.ok) {
+          const data = await userRes.json();
+          setUserInfo(data);
+        }
+        const subRes = await fetch(`${BACKEND_URL}/api/users/${id}/submissions`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (subRes.ok) {
+          const subData = await subRes.json();
+          setSubmissions(subData);
+        }
+      } catch (err) {
+        console.error('Failed to fetch friend profile', err);
+      }
+    }
+    fetchData();
+  }, [id, navigate]);
+
+  const heatmapCounts = submissions.reduce((acc, sub) => {
+    const date = new Date(sub.createdAt).toISOString().split('T')[0];
+    acc[date] = (acc[date] || 0) + 1;
+    return acc;
+  }, {});
+  const heatmapValues = Object.keys(heatmapCounts).map((date) => ({ date, count: heatmapCounts[date] }));
+
+  return (
+    <div>
+      <NavBar />
+      <div className="profile-container">
+        <div className="profile-header">
+          <div className="profile-avatar">
+            <img src={defaultAvatar} alt="avatar" />
+          </div>
+          <div className="profile-info">
+            <div className="profile-handle">
+              {userInfo.displayName || userInfo.username || 'User'}
+              <span className="user-rating">Unrated</span>
+            </div>
+            <div className="profile-stats">
+              <span>Contributions: {submissions.length}</span>
+              <span>Friends: {userInfo.friends ? userInfo.friends.length : 0}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="profile-heatmap">
+          <h2>Submission Activity</h2>
+          <CalendarHeatmap
+            startDate={new Date(new Date().getFullYear(), 0, 1)}
+            endDate={new Date(new Date().getFullYear(), 11, 31)}
+            values={heatmapValues}
+            classForValue={(value) => {
+              if (!value || !value.count) {
+                return 'color-empty';
+              }
+              return `color-scale-${Math.min(value.count, 4)}`;
+            }}
+            tooltipDataAttrs={(value) => ({ title: `${value.date}: ${value.count || 0} submissions` })}
+          />
+        </div>
+
+        <div className="profile-submissions">
+          <h2>Recent Submissions</h2>
+          <table className="submissions-table">
+            <thead>
+              <tr>
+                <th>Problem</th>
+                <th>Verdict</th>
+                <th>Language</th>
+                <th>Time</th>
+              </tr>
+            </thead>
+            <tbody>
+              {submissions.map((sub) => (
+                <tr key={sub._id}>
+                  <td>{sub.problem}</td>
+                  <td className={`verdict ${sub.verdict.toLowerCase().replace(/\s+/g, '-')}`}>
+                    {sub.verdict}
+                  </td>
+                  <td>{sub.language}</td>
+                  <td>{new Date(sub.createdAt).toLocaleString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default FriendProfilePage;

--- a/codespace/frontend/src/pages/ProfilePage.js
+++ b/codespace/frontend/src/pages/ProfilePage.js
@@ -118,7 +118,13 @@ function ProfilePage() {
             <h3>Friends</h3>
             <ul>
               {(userInfo.friends || []).map((f) => (
-                <li key={f._id}>{f.displayName || f.username}</li>
+                <li
+                  key={f._id}
+                  onClick={() => navigate(`/profile/${f._id}`)}
+                  className="friend-item"
+                >
+                  {f.displayName || f.username}
+                </li>
               ))}
             </ul>
           </div>

--- a/codespace/frontend/src/styles/ProfilePage.css
+++ b/codespace/frontend/src/styles/ProfilePage.css
@@ -69,6 +69,10 @@
   margin-top: 20px;
 }
 
+.friend-item {
+  cursor: pointer;
+}
+
 .edit-form {
   margin-top: 20px;
 }

--- a/codespace/server/routes/users.js
+++ b/codespace/server/routes/users.js
@@ -26,10 +26,14 @@ function authenticate(req, res, next) {
 
 router.get('/:id/submissions', authenticate, async (req, res) => {
   const { id } = req.params;
-  if (req.user.id !== id) {
-    return res.status(403).json({ message: 'Forbidden' });
-  }
   try {
+    if (req.user.id !== id) {
+      const current = await User.findById(req.user.id).select('friends');
+      const isFriend = current && current.friends.some((f) => f.toString() === id);
+      if (!isFriend) {
+        return res.status(403).json({ message: 'Forbidden' });
+      }
+    }
     const submissions = await Submission.find({ user: id }).sort({ createdAt: -1 });
     res.json(submissions);
   } catch (err) {
@@ -104,10 +108,14 @@ router.get('/search', authenticate, async (req, res) => {
 
 router.get('/:id', authenticate, async (req, res) => {
   const { id } = req.params;
-  if (req.user.id !== id) {
-    return res.status(403).json({ message: 'Forbidden' });
-  }
   try {
+    if (req.user.id !== id) {
+      const current = await User.findById(req.user.id).select('friends');
+      const isFriend = current && current.friends.some((f) => f.toString() === id);
+      if (!isFriend) {
+        return res.status(403).json({ message: 'Forbidden' });
+      }
+    }
     const user = await User.findById(id).populate('friends', 'username displayName');
     if (!user) {
       return res.status(404).json({ message: 'User not found' });


### PR DESCRIPTION
## Summary
- Allow users to view a friend's profile and submissions when visiting from friends list
- Make friends list items clickable and add dedicated friend profile page with heatmap
- Permit friend access on backend user and submissions routes

## Testing
- `npm test` (server)
- `npm test -- --watchAll=false` (frontend) *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*


------
https://chatgpt.com/codex/tasks/task_e_68bf1194e0a8832899d88c42a76c3d47