### PR TITLE
Redesign problems page with card layout and footer pagination

### DIFF
--- a/codespace/frontend/src/components/ProblemTable.js
+++ b/codespace/frontend/src/components/ProblemTable.js
@@ -1,14 +1,11 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 function ProblemTable({ problems }) {
-  const [currentPage, setCurrentPage] = useState(1);
-  const itemsPerPage = 10;
-  const totalPages = Math.ceil(problems.length / itemsPerPage) || 1;
-
   const openLink = (link) => {
-    const url = link.startsWith('http://') || link.startsWith('https://')
-      ? link
-      : `https://${link}`;
+    const url =
+      link.startsWith('http://') || link.startsWith('https://')
+        ? link
+        : `https://${link}`;
     window.open(url, '_blank', 'noopener,noreferrer');
   };
 
@@ -21,44 +18,29 @@ function ProblemTable({ problems }) {
     }
   };
 
-  const current = problems.slice(
-    (currentPage - 1) * itemsPerPage,
-    currentPage * itemsPerPage
-  );
-
   return (
     <div className="right-problems">
-      <table className="problem-table">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Topic</th>
-            <th>Subtopic</th>
-            <th>Website</th>
-            <th>Difficulty</th>
-          </tr>
-        </thead>
-        <tbody>
-          {current.map((p) => (
-            <tr key={p._id} onClick={() => openLink(p.link)}>
-              <td>{p.name}</td>
-              <td>{p.topic}</td>
-              <td>{p.subtopic}</td>
-              <td>{p.domain || getDomain(p.link)}</td>
-              <td>{p.difficulty}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-      <div className="pagination">
-        {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
-          <button
-            key={page}
-            onClick={() => setCurrentPage(page)}
-            className={page === currentPage ? 'active' : ''}
+      <div className="problem-grid">
+        {problems.map((p) => (
+          <div
+            key={p._id}
+            className="problem-card"
+            onClick={() => openLink(p.link)}
           >
-            {page}
-          </button>
+            <h3>{p.name}</h3>
+            <p>
+              <strong>Topic:</strong> {p.topic}
+            </p>
+            <p>
+              <strong>Subtopic:</strong> {p.subtopic}
+            </p>
+            <p>
+              <strong>Website:</strong> {p.domain || getDomain(p.link)}
+            </p>
+            <p>
+              <strong>Difficulty:</strong> {p.difficulty}
+            </p>
+          </div>
         ))}
       </div>
     </div>

--- a/codespace/frontend/src/pages/ProblemsPage.js
+++ b/codespace/frontend/src/pages/ProblemsPage.js
@@ -28,6 +28,8 @@ function ProblemsPage() {
   const [newSubtopic, setNewSubtopic] = useState({ stage: '', topic: '', name: '' });
   const role = localStorage.getItem('role');
   const isAdmin = role === 'admin' || role === 'superadmin';
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 10;
 
   useEffect(() => {
     const fetchProblems = async () => {
@@ -141,6 +143,16 @@ function ProblemsPage() {
     return matchesStage && matchesTopic && matchesSubtopic && matchesSearch;
   });
 
+  const totalPages = Math.ceil(filteredProblems.length / itemsPerPage) || 1;
+  const currentProblems = filteredProblems.slice(
+    (currentPage - 1) * itemsPerPage,
+    currentPage * itemsPerPage
+  );
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [search, selectedStage, selectedTopic, selectedSubtopic]);
+
   return (
     <div>
       <NavBar />
@@ -179,8 +191,19 @@ function ProblemsPage() {
             selectedSubtopic={selectedSubtopic}
             setSelectedSubtopic={setSelectedSubtopic}
           />
-          <ProblemTable problems={filteredProblems} />
+          <ProblemTable problems={currentProblems} />
         </div>
+        <footer className="pagination">
+          {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+            <button
+              key={page}
+              onClick={() => setCurrentPage(page)}
+              className={page === currentPage ? 'active' : ''}
+            >
+              {page}
+            </button>
+          ))}
+        </footer>
       </div>
     </div>
   );

--- a/codespace/frontend/src/styles/ProblemsPage.css
+++ b/codespace/frontend/src/styles/ProblemsPage.css
@@ -100,33 +100,29 @@
   height: 100%;
 }
 
-
-.problem-table {
-  width: 100%;
-  border-collapse: collapse;
-  color: #111827;
+.problem-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 16px;
 }
 
-.problem-table th,
-.problem-table td {
+.problem-card {
   border: 1px solid #444;
-  padding: 8px;
-  text-align: center;
-  vertical-align: middle;
-}
-
-.problem-table tr {
+  border-radius: 8px;
+  padding: 12px;
+  background: #f9fafb;
   cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
-.problem-table tr:hover {
+.problem-card:hover {
   background: #f3f4f6;
 }
 
 .pagination {
   display: flex;
   justify-content: center;
-  margin-top: 10px;
+  margin-top: 20px;
   gap: 8px;
 }
 


### PR DESCRIPTION
## Summary
- Display problems as cards rather than a plain table
- Move pagination controls to the page footer
- Update styling for grid layout and footer navigation

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*

------
https://chatgpt.com/codex/tasks/task_e_68bf16c400a083289b164b67a065f37d