### PR TITLE
Improve resource section layout and scrolling

### DIFF
--- a/codespace/frontend/src/styles/ResourcesPage.css
+++ b/codespace/frontend/src/styles/ResourcesPage.css
@@ -2,6 +2,8 @@
   display: flex;
   flex-direction: column;
   padding: 20px;
+  height: 100vh;
+  overflow-y: auto;
 }
 
 .search-bar {
@@ -20,7 +22,8 @@
 
 .resources-content {
   display: flex;
-  height: 80vh;
+  flex: 1;
+  min-height: 0;
 }
 
 .left-menu {
@@ -98,7 +101,8 @@
   width: 75%;
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-  gap: 15px;
+  column-gap: 20px;
+  row-gap: 20px;
   overflow-y: auto;
   height: 100%;
 }
@@ -114,7 +118,7 @@
   border-radius: 8px;
   position: relative;
   cursor: pointer;
-  max-height: 20%;
+  min-height: 120px;
 }
 
 .resource-header {


### PR DESCRIPTION
## Summary
- ensure resource page scrolls when content exceeds the viewport
- apply fixed spacing for resource grid and remove card height constraint

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*

------
https://chatgpt.com/codex/tasks/task_e_68bf190ffc488328a342d61baaf5d3c9