### PR TITLE
Use absolute script path for C++ container

### DIFF
--- a/codespace/server/jobs/submissionWorker.js
+++ b/codespace/server/jobs/submissionWorker.js
@@ -169,8 +169,8 @@ async function submissionWorker(job) {
                 } else {
                     const containerOptions = {
                         Image: 'nubskr/compiler:1',
-                        Cmd: ['./doshit.sh'],
-                        WorkingDir: '/contest',
+                        Cmd: ['/doshit.sh'],
+                        WorkingDir: '/',
                         HostConfig: {
                             Memory: 256 * 1024 * 1024, // 256MB
                             PidsLimit: 100, // Limit number of processes


### PR DESCRIPTION
## Summary
- call C++ compilation container with `/doshit.sh` and root working directory

## Testing
- `npm test`
- `docker build -t nubskr/compiler:1 Docker` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3140ddc8832886bf578e21fce776