### PR TITLE
Improve custom problem panel and AI test generation

### DIFF
--- a/codespace/frontend/src/components/AsyncButton.js
+++ b/codespace/frontend/src/components/AsyncButton.js
@@ -3,7 +3,7 @@ import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 
-const AsyncButton = ({ onClick, onSuccess, children, ...props }) => {
+const AsyncButton = ({ onClick, onSuccess, children, sx, ...props }) => {
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
 
@@ -17,14 +17,19 @@ const AsyncButton = ({ onClick, onSuccess, children, ...props }) => {
         if (onSuccess) {
           onSuccess();
         }
-      }, 2000);
+      }, 1000);
     } finally {
       setLoading(false);
     }
   };
 
   return (
-    <Button {...props} onClick={handleClick} disabled={loading}>
+    <Button
+      {...props}
+      onClick={handleClick}
+      disabled={loading}
+      sx={{ minWidth: 120, ...(sx || {}) }}
+    >
       {loading ? <CircularProgress size={20} /> : success ? <CheckCircleIcon color="success" /> : children}
     </Button>
   );

--- a/codespace/frontend/src/components/CustomProblemPanel.js
+++ b/codespace/frontend/src/components/CustomProblemPanel.js
@@ -2,13 +2,14 @@ import React, { useState } from 'react';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 import AsyncButton from './AsyncButton';
 import axios from 'axios';
 import BACKEND_URL from '../config';
 
 const CustomProblemPanel = ({ onAdd, onClose }) => {
   const [statement, setStatement] = useState('');
-  const [tests, setTests] = useState([]);
+  const [tests, setTests] = useState([{ input: '', output: '' }]);
 
   const handleVerify = async () => {
     const res = await axios.post(`${BACKEND_URL}/api/ai/verify-problem`, { statement });
@@ -24,12 +25,20 @@ const CustomProblemPanel = ({ onAdd, onClose }) => {
     }
   };
 
+  const handleTestChange = (index, field, value) => {
+    setTests(prev => {
+      const updated = [...prev];
+      updated[index] = { ...updated[index], [field]: value };
+      return updated;
+    });
+  };
+
   const handleAdd = async () => {
     await onAdd(statement, tests);
   };
 
   return (
-    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, width: 600 }}>
       <TextField
         multiline
         minRows={6}
@@ -37,9 +46,39 @@ const CustomProblemPanel = ({ onAdd, onClose }) => {
         onChange={(e) => setStatement(e.target.value)}
         placeholder="Write your problem statement here"
       />
+      <Box>
+        <Typography variant="subtitle1" sx={{ mb: 1 }}>Sample Tests</Typography>
+        {tests.map((test, idx) => (
+          <Stack key={idx} direction="row" spacing={2} sx={{ mb: 1 }}>
+            <TextField
+              label={`Input ${idx + 1}`}
+              multiline
+              minRows={2}
+              value={test.input}
+              onChange={(e) => handleTestChange(idx, 'input', e.target.value)}
+              fullWidth
+            />
+            <TextField
+              label={`Output ${idx + 1}`}
+              multiline
+              minRows={2}
+              value={test.output}
+              onChange={(e) => handleTestChange(idx, 'output', e.target.value)}
+              fullWidth
+            />
+          </Stack>
+        ))}
+        <AsyncButton
+          size="small"
+          variant="outlined"
+          onClick={handleGenerate}
+          sx={{ minWidth: 160 }}
+        >
+          AI Generate Tests
+        </AsyncButton>
+      </Box>
       <Stack direction="row" spacing={2} justifyContent="center">
         <AsyncButton variant="contained" onClick={handleVerify}>Verify</AsyncButton>
-        <AsyncButton variant="contained" onClick={handleGenerate}>Generate Tests</AsyncButton>
         <AsyncButton variant="contained" onClick={handleAdd} onSuccess={onClose}>Add</AsyncButton>
       </Stack>
     </Box>

--- a/codespace/server/routes/ai.js
+++ b/codespace/server/routes/ai.js
@@ -65,7 +65,7 @@ router.post('/generate-tests', async (req, res) => {
   if (!apiKey) {
     return res.status(500).json({ error: 'Missing GEMINI_API_KEY' });
   }
-  const text = `Generate a JSON array of test cases for the following competitive programming problem. Each test should be an object with "input" and "output" fields. Only return the JSON.\n\n${statement}`;
+  const text = `Generate a JSON array of test cases for the following competitive programming problem. Each test should be an object with "input" and "output" fields. Avoid large inputs (no test should contain more than 1000 integers). Only return the JSON.\n\n${statement}`;
   try {
     const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
       method: 'POST',


### PR DESCRIPTION
## Summary
- Keep async buttons compact and shorten success tick display
- Add editable sample test sections and AI generation in custom problem panel
- Prevent AI system test prompts from generating extremely large cases

## Testing
- `npm test` (server)
- `npm test` (frontend) *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*

------
https://chatgpt.com/codex/tasks/task_e_68bf4296f34483288e9598de5ae94f2e