### PR TITLE
feat: support dynamic ai test generation

### DIFF
--- a/codespace/frontend/src/components/CustomProblemPanel.js
+++ b/codespace/frontend/src/components/CustomProblemPanel.js
@@ -23,7 +23,11 @@ const CustomProblemPanel = ({ onAdd, onClose }) => {
   };
 
   const handleGenerateSample = async () => {
-    const res = await axios.post(`${BACKEND_URL}/api/ai/generate-average-tests`, { type: 'sample' });
+    const res = await axios.post(`${BACKEND_URL}/api/ai/generate-tests`, {
+      statement,
+      count: 1,
+      maxArrayLength: maxLen,
+    });
     if (res.data.tests && res.data.tests[0]) {
       setSampleInput(res.data.tests[0].input);
       setSampleOutput(res.data.tests[0].output);
@@ -31,8 +35,8 @@ const CustomProblemPanel = ({ onAdd, onClose }) => {
   };
 
   const handleGenerateHidden = async () => {
-    const res = await axios.post(`${BACKEND_URL}/api/ai/generate-average-tests`, {
-      type: 'hidden',
+    const res = await axios.post(`${BACKEND_URL}/api/ai/generate-tests`, {
+      statement,
       count: hiddenCount,
       maxArrayLength: maxLen,
     });
@@ -119,26 +123,28 @@ const CustomProblemPanel = ({ onAdd, onClose }) => {
             Generate Hidden
           </AsyncButton>
         </Stack>
-        {tests.map((test, idx) => (
-          <Stack key={idx} direction="row" spacing={2} sx={{ mb: 1 }}>
-            <TextField
-              label={`Input ${idx + 1}`}
-              multiline
-              minRows={2}
-              value={test.input}
-              onChange={(e) => handleHiddenChange(idx, 'input', e.target.value)}
-              fullWidth
-            />
-            <TextField
-              label={`Output ${idx + 1}`}
-              multiline
-              minRows={2}
-              value={test.output}
-              onChange={(e) => handleHiddenChange(idx, 'output', e.target.value)}
-              fullWidth
-            />
-          </Stack>
-        ))}
+        <Box sx={{ maxHeight: 200, overflowY: 'auto' }}>
+          {tests.map((test, idx) => (
+            <Stack key={idx} direction="row" spacing={2} sx={{ mb: 1 }}>
+              <TextField
+                label={`Input ${idx + 1}`}
+                multiline
+                minRows={2}
+                value={test.input}
+                onChange={(e) => handleHiddenChange(idx, 'input', e.target.value)}
+                fullWidth
+              />
+              <TextField
+                label={`Output ${idx + 1}`}
+                multiline
+                minRows={2}
+                value={test.output}
+                onChange={(e) => handleHiddenChange(idx, 'output', e.target.value)}
+                fullWidth
+              />
+            </Stack>
+          ))}
+        </Box>
       </Box>
 
       <Stack direction="row" spacing={2} justifyContent="center">

--- a/codespace/server/routes/ai.js
+++ b/codespace/server/routes/ai.js
@@ -4,7 +4,7 @@ const router = express.Router();
 
 router.post('/chat', async (req, res) => {
   const { prompt = '', code = '', mode = 'normal' } = req.body;
-  const apiKey = "AIzaSyCxEUSKz296qV7qCFgNvRe_7jYMe9Y8LyI"
+  const apiKey = "AIzaSyCxEUSKz296qV7qCFgNvRe_7jYMe9Y8LyI";
   if (!apiKey) {
     return res.status(500).json({ error: 'Missing GEMINI_API_KEY' });
   }
@@ -15,17 +15,22 @@ router.post('/chat', async (req, res) => {
     text = `${prompt}\n\nExplain the following code:\n${code}`;
   }
   try {
-    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        contents: [{ role: 'user', parts: [{ text }] }]
-      })
-    });
+    const response = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ contents: [{ role: 'user', parts: [{ text }] }] })
+      }
+    );
     const data = await response.json();
-    const aiText = data.candidates && data.candidates[0] && data.candidates[0].content && data.candidates[0].content.parts
-      ? data.candidates[0].content.parts.map(p => p.text).join('')
-      : 'No response';
+    const aiText =
+      data.candidates &&
+      data.candidates[0] &&
+      data.candidates[0].content &&
+      data.candidates[0].content.parts
+        ? data.candidates[0].content.parts.map((p) => p.text).join('')
+        : 'No response';
     res.json({ text: aiText });
   } catch (err) {
     console.error(err);
@@ -41,17 +46,22 @@ router.post('/verify-problem', async (req, res) => {
   }
   const text = `You are a competitive programming problem validator. If the following statement is missing information or is unclear, rewrite it to be complete and unambiguous. Otherwise reply with the original statement.\n\n${statement}`;
   try {
-    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        contents: [{ role: 'user', parts: [{ text }] }]
-      })
-    });
+    const response = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ contents: [{ role: 'user', parts: [{ text }] }] })
+      }
+    );
     const data = await response.json();
-    const aiText = data.candidates && data.candidates[0] && data.candidates[0].content && data.candidates[0].content.parts
-      ? data.candidates[0].content.parts.map(p => p.text).join('')
-      : statement;
+    const aiText =
+      data.candidates &&
+      data.candidates[0] &&
+      data.candidates[0].content &&
+      data.candidates[0].content.parts
+        ? data.candidates[0].content.parts.map((p) => p.text).join('')
+        : statement;
     res.json({ statement: aiText });
   } catch (err) {
     console.error(err);
@@ -60,28 +70,31 @@ router.post('/verify-problem', async (req, res) => {
 });
 
 router.post('/generate-tests', async (req, res) => {
-  const { statement = '' } = req.body;
+  const { statement = '', count = 1, maxArrayLength = 1000 } = req.body;
   const apiKey = "AIzaSyCxEUSKz296qV7qCFgNvRe_7jYMe9Y8LyI";
   if (!apiKey) {
     return res.status(500).json({ error: 'Missing GEMINI_API_KEY' });
   }
-  const text = `Generate a JSON array of test cases for the following competitive programming problem. Each test should be an object with "input" and "output" fields. Avoid large inputs (no test should contain more than 1000 integers). Only return the JSON.\n\n${statement}`;
+  const text = `Generate a JSON array of exactly ${count} test cases for the following competitive programming problem. Each test should be an object with \"input\" and \"output\" fields. Ensure that any array in the input contains at most ${maxArrayLength} elements. Only return the JSON array.\n\n${statement}`;
   try {
-    const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        contents: [{ role: 'user', parts: [{ text }] }]
-      })
-    });
+    const response = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ contents: [{ role: 'user', parts: [{ text }] }] })
+      }
+    );
     const data = await response.json();
-    const aiText = data.candidates && data.candidates[0] && data.candidates[0].content && data.candidates[0].content.parts
-      ? data.candidates[0].content.parts.map(p => p.text).join('')
-      : '[]';
+    const aiText =
+      data.candidates &&
+      data.candidates[0] &&
+      data.candidates[0].content &&
+      data.candidates[0].content.parts
+        ? data.candidates[0].content.parts.map((p) => p.text).join('')
+        : '[]';
     let tests = [];
     try {
-      // Some responses may include additional text or code fences around the
-      // JSON array. Extract the first JSON array substring and parse that.
       const match = aiText.match(/\[[\s\S]*\]/);
       if (match) {
         tests = JSON.parse(match[0]);
@@ -98,35 +111,5 @@ router.post('/generate-tests', async (req, res) => {
   }
 });
 
-// Utility for formatting average with up to 4 decimal places without
-// unnecessary trailing zeros. For example, 3.4000 becomes "3.4".
-function formatAvg(num) {
-  let s = num.toFixed(4);
-  s = s.replace(/\.0+$/, '');
-  s = s.replace(/(\.\d*?[1-9])0+$/, '$1');
-  return s;
-}
-
-// Generates test cases for the array average problem. It supports two modes:
-// - sample: returns a single small test for the problem statement.
-// - hidden: returns multiple tests for system testing. The client may specify
-//   the number of tests (count) and the maximum array length.
-router.post('/generate-average-tests', (req, res) => {
-  const { type = 'sample', count = 1, maxArrayLength = 10 } = req.body;
-
-  const numTests = type === 'sample' ? 1 : Math.max(1, Math.floor(count));
-  const maxLen = Math.max(1, Math.floor(maxArrayLength));
-
-  const tests = [];
-  for (let i = 0; i < numTests; i++) {
-    const n = Math.floor(Math.random() * maxLen) + 1;
-    const arr = Array.from({ length: n }, () => Math.floor(Math.random() * 1e9) + 1);
-    const avg = arr.reduce((a, b) => a + b, 0) / n;
-    const output = formatAvg(avg);
-    tests.push({ input: `${n}\n${arr.join(' ')}`, output });
-  }
-
-  res.json({ tests });
-});
-
 module.exports = router;
+


### PR DESCRIPTION
## Summary
- replace average-only endpoints with generic `/api/ai/generate-tests` that accepts statement, test count and max array length
- run each hidden test individually in submission worker to avoid concatenated input
- show generated hidden tests in a scrollable panel

## Testing
- `cd codespace/server && npm test`
- `cd codespace/frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0443e14dc832881e9af64c1edb411