### PR TITLE
Handle whitespace in output comparison and run all hidden tests

### DIFF
--- a/codespace/Docker/doshit.sh
+++ b/codespace/Docker/doshit.sh
@@ -63,7 +63,7 @@ else
         touch $output_path
     fi
 
-    diff --brief $output_path $expected_output_path > $compare_path
+    diff -wB $output_path $expected_output_path > $compare_path
     cat $compare_path
     
     if [ -s $compare_path ]; then


### PR DESCRIPTION
## Summary
- Normalize output comparisons to ignore trailing whitespace across languages
- Split stored test package lines into multiple test cases for evaluation
- Relax C++ diff to ignore whitespace differences

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c04b99b258832880d3e0976f485c27