### PR TITLE
Persist room state in database

### DIFF
--- a/codespace/server/model/roomModel.js
+++ b/codespace/server/model/roomModel.js
@@ -1,10 +1,26 @@
 const mongoose = require('mongoose');
 const Message = require('./messageModel');
 
+const testSchema = new mongoose.Schema(
+  {
+    input: { type: String },
+    output: { type: String },
+  },
+  { _id: false }
+);
+
 const roomSchema = new mongoose.Schema({
   roomid: { type: String, required: true, unique: true, match: /^\d{4}$/ },
   isPrivate: { type: Boolean, default: false },
   password: { type: String },
+  // persisted collaborative state
+  code: { type: String, default: '' },
+  statement: { type: String, default: '' },
+  sampleInput: { type: String, default: '' },
+  sampleOutput: { type: String, default: '' },
+  language: { type: String, default: 'cpp' },
+  input: { type: String, default: '' },
+  tests: { type: [testSchema], default: [] },
 });
 
 roomSchema.pre('findOneAndDelete', async function (next) {


### PR DESCRIPTION
## Summary
- store code, language and problem details for each room in MongoDB
- load persisted room state when users join
- keep database in sync when code or problem updates occur

## Testing
- `npm test`
- `CI=true npm test -- --watchAll=false` *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*


------
https://chatgpt.com/codex/tasks/task_e_68c0507571f08328845afaf3969d9997