### PR TITLE
Ensure room code is delivered to new joiners

### DIFF
--- a/codespace/frontend/src/components/TextBox.js
+++ b/codespace/frontend/src/components/TextBox.js
@@ -99,6 +99,7 @@ export default function TextBox({socketRef,currentProbId,tests,onCodeChange,room
             onCodeChange && onCodeChange(payload.code);
         };
         socketRef.current.on('receive-code-update', handleCodeUpdate);
+        socketRef.current.emit('request-code');
         return () => {
             socketRef.current.off('receive-code-update', handleCodeUpdate);
         };

--- a/codespace/server/app.js
+++ b/codespace/server/app.js
@@ -145,7 +145,14 @@ io.on('connection', (socket) => {
             socket.emit('ai-chat-history', state.aiChat);
         }
     })
-    
+
+    socket.on('request-code', () => {
+        const state = getRoomState(socket.roomid);
+        if (state.code) {
+            socket.emit('receive-code-update', { code: state.code });
+        }
+    });
+
     socket.on('update-code', async (payload) => {
         const state = getRoomState(socket.roomid);
         state.code = payload.code;


### PR DESCRIPTION
## Summary
- send existing room code to clients that request it when joining
- request initial code from server when the editor mounts

## Testing
- `npm test` (server)
- `CI=true npm test` (frontend) *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*


------
https://chatgpt.com/codex/tasks/task_e_68c0933f6fb08328a77d9b56695cb36e