### PR TITLE
Ensure MUI modals fit within viewport

### DIFF
--- a/codespace/frontend/src/components/LHS/NestedModal.js
+++ b/codespace/frontend/src/components/LHS/NestedModal.js
@@ -14,13 +14,14 @@ const style = {
   top: '50%',
   left: '50%',
   transform: 'translate(-50%, -50%)',
-  width: '100px',
   bgcolor: 'background.paper',
   border: '2px solid #000',
   boxShadow: 24,
   pt: 2,
   px: 4,
   pb: 3,
+  maxWidth: '90vw',
+  maxHeight: '90vh',
   overflow: 'auto',
 };
 

--- a/codespace/frontend/src/components/LHS/ProblemInputModal.js
+++ b/codespace/frontend/src/components/LHS/ProblemInputModal.js
@@ -16,12 +16,14 @@ const style = {
   top: '50%',
   left: '50%',
   transform: 'translate(-50%, -50%)',
-  width: 1000,
-  height: 500,
+  width: '90vw',
+  maxWidth: 1000,
+  maxHeight: '90vh',
   bgcolor: 'background.paper',
   border: '2px solid #000',
   boxShadow: 24,
   p: 4,
+  overflowY: 'auto',
 };
 
 export default function ProblemInputModal({text,setText,input,setInput}) {

--- a/codespace/frontend/src/components/Room.js
+++ b/codespace/frontend/src/components/Room.js
@@ -58,6 +58,9 @@ const modalStyle = {
   transform: 'translate(-50%, -50%)',
   backgroundColor: 'white',
   padding: '20px',
+  maxWidth: '90vw',
+  maxHeight: '90vh',
+  overflowY: 'auto',
 };
 
 export default function Room() {


### PR DESCRIPTION
## Summary
- Make ProblemInputModal responsive and scrollable within viewport
- Enforce viewport-based max dimensions on nested modals
- Add overflow handling to Room's custom problem modal

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*

------
https://chatgpt.com/codex/tasks/task_e_68c16c42c08483289b1eae49694d0b16