### PR TITLE
Show failing test number and allow viewing submission code

### DIFF
--- a/codespace/frontend/src/pages/FriendProfilePage.js
+++ b/codespace/frontend/src/pages/FriendProfilePage.js
@@ -11,6 +11,7 @@ function FriendProfilePage() {
   const { id } = useParams();
   const [submissions, setSubmissions] = useState([]);
   const [userInfo, setUserInfo] = useState({ username: '', displayName: '', friends: [] });
+  const [expanded, setExpanded] = useState(null);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -98,14 +99,26 @@ function FriendProfilePage() {
             </thead>
             <tbody>
               {submissions.map((sub) => (
-                <tr key={sub._id}>
-                  <td>{sub.problem}</td>
-                  <td className={`verdict ${sub.verdict.toLowerCase().replace(/\s+/g, '-')}`}>
-                    {sub.verdict}
-                  </td>
-                  <td>{sub.language}</td>
-                  <td>{new Date(sub.createdAt).toLocaleString()}</td>
-                </tr>
+                <React.Fragment key={sub._id}>
+                  <tr
+                    className="submission-row"
+                    onClick={() => setExpanded(expanded === sub._id ? null : sub._id)}
+                  >
+                    <td>{sub.problem}</td>
+                    <td className={`verdict ${sub.verdict.toLowerCase().replace(/\s+/g, '-')}`}>
+                      {sub.verdict}
+                    </td>
+                    <td>{sub.language}</td>
+                    <td>{new Date(sub.createdAt).toLocaleString()}</td>
+                  </tr>
+                  {expanded === sub._id && (
+                    <tr className="code-row">
+                      <td colSpan="4">
+                        <pre>{sub.code}</pre>
+                      </td>
+                    </tr>
+                  )}
+                </React.Fragment>
               ))}
             </tbody>
           </table>

--- a/codespace/frontend/src/pages/ProfilePage.js
+++ b/codespace/frontend/src/pages/ProfilePage.js
@@ -13,6 +13,7 @@ function ProfilePage() {
   const [showEdit, setShowEdit] = useState(false);
   const [showFriends, setShowFriends] = useState(false);
   const [form, setForm] = useState({ username: '', displayName: '', password: '', currentPassword: '' });
+  const [expanded, setExpanded] = useState(null);
   const userId = localStorage.getItem('userid');
   const navigate = useNavigate();
 
@@ -190,17 +191,30 @@ function ProfilePage() {
             </thead>
             <tbody>
               {submissions.map((sub) => (
-                <tr key={sub._id}>
-                  <td>{sub.problem}</td>
-                  <td className={`verdict ${sub.verdict
-                    .toLowerCase()
-                    .replace(/\s+/g, '-')}`}
+                <React.Fragment key={sub._id}>
+                  <tr
+                    className="submission-row"
+                    onClick={() => setExpanded(expanded === sub._id ? null : sub._id)}
                   >
-                    {sub.verdict}
-                  </td>
-                  <td>{sub.language}</td>
-                  <td>{new Date(sub.createdAt).toLocaleString()}</td>
-                </tr>
+                    <td>{sub.problem}</td>
+                    <td
+                      className={`verdict ${sub.verdict
+                        .toLowerCase()
+                        .replace(/\s+/g, '-')}`}
+                    >
+                      {sub.verdict}
+                    </td>
+                    <td>{sub.language}</td>
+                    <td>{new Date(sub.createdAt).toLocaleString()}</td>
+                  </tr>
+                  {expanded === sub._id && (
+                    <tr className="code-row">
+                      <td colSpan="4">
+                        <pre>{sub.code}</pre>
+                      </td>
+                    </tr>
+                  )}
+                </React.Fragment>
               ))}
             </tbody>
           </table>

--- a/codespace/frontend/src/styles/ProfilePage.css
+++ b/codespace/frontend/src/styles/ProfilePage.css
@@ -146,3 +146,16 @@
   color: #a00;
   font-weight: bold;
 }
+
+.submission-row {
+  cursor: pointer;
+}
+
+.code-row td {
+  background: #f7f7f7;
+}
+
+.code-row pre {
+  margin: 0;
+  white-space: pre-wrap;
+}

--- a/codespace/server/jobs/submissionWorker.js
+++ b/codespace/server/jobs/submissionWorker.js
@@ -125,7 +125,8 @@ async function submissionWorker(job) {
                         .map(line => line.trim())
                         .join('\n');
 
-                for (const t of testsToRun) {
+                for (let i = 0; i < testsToRun.length; i++) {
+                    const t = testsToRun[i];
                     await changeFile(inputfilepath, t.input);
                     await changeFile(expectedoutputpath, t.output);
                     await changeFile(sourcefilepath, code);
@@ -206,6 +207,7 @@ async function submissionWorker(job) {
                     }
 
                     if (verdictData !== 'Accepted') {
+                        verdictData = `${verdictData} on test ${i + 1}`;
                         break;
                     }
                 }

--- a/codespace/server/routes/submit.js
+++ b/codespace/server/routes/submit.js
@@ -5,6 +5,7 @@ const router = express.Router();
 
 const { submissionQueue, waitforJobCompletion } = require('../jobs/submissionWorker');
 const Submission = require('../model/submissionModel');
+const PracticeProblem = require('../model/practiceProblemModel');
 
 const url = process.env.MONGODB_URI || 'mongodb://localhost:27017/graduation_project';
 mongoose.connect(url);
@@ -49,9 +50,14 @@ router.post('/', authenticate, async (req, res) => {
   }
 
   try {
+    let problemName = 'Custom Problem';
+    if (problem_id) {
+      const problem = await PracticeProblem.findOne({ id: problem_id }).select('name');
+      problemName = problem ? problem.name : problem_id;
+    }
     const submission = new Submission({
       user: req.user.id,
-      problem: problem_id || 'custom',
+      problem: problemName,
       code,
       verdict: verdictData,
       language,


### PR DESCRIPTION
## Summary
- Save submission with human-readable problem name and include failing test index in verdict
- Allow users to expand submissions on profile pages to view submitted code
- Add UI styling for expandable code rows in profiles

## Testing
- `cd codespace/server && npm test`
- `cd codespace/frontend && npm test -- --watchAll=false` *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*


------
https://chatgpt.com/codex/tasks/task_e_68c172d1c5f483288ec17d88a895018e