### PR TITLE
Enhance main screen with animated logo

### DIFF
--- a/AndroidApp/App.tsx
+++ b/AndroidApp/App.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, {useEffect, useRef} from 'react';
 import {NavigationContainer} from '@react-navigation/native';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
-import {View, Text, StyleSheet} from 'react-native';
+import {View, Text, StyleSheet, Animated, Easing} from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import AsyncButton from './src/components/AsyncButton';
 import BACKEND_URL from './src/config';
@@ -13,8 +13,33 @@ function HomeScreen(): React.JSX.Element {
     await AsyncStorage.setItem('lastPress', new Date().toISOString());
   };
 
+  const bounce = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.loop(
+      Animated.sequence([
+        Animated.timing(bounce, {
+          toValue: -20,
+          duration: 1000,
+          easing: Easing.inOut(Easing.quad),
+          useNativeDriver: true,
+        }),
+        Animated.timing(bounce, {
+          toValue: 0,
+          duration: 1000,
+          easing: Easing.inOut(Easing.quad),
+          useNativeDriver: true,
+        }),
+      ]),
+    ).start();
+  }, [bounce]);
+
   return (
     <View style={styles.container}>
+      <Animated.Image
+        source={require('./src/assets/logo.png')}
+        style={[styles.logo, {transform: [{translateY: bounce}]}]}
+      />
       <Text style={styles.title}>Backend: {BACKEND_URL}</Text>
       <AsyncButton onPress={saveTime}>Save Timestamp</AsyncButton>
     </View>
@@ -36,6 +61,11 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  logo: {
+    width: 100,
+    height: 100,
+    marginBottom: 20,
   },
   title: {
     marginBottom: 16,

--- a/AndroidApp/__mocks__/fileMock.js
+++ b/AndroidApp/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = '';

--- a/AndroidApp/__tests__/App.test.tsx
+++ b/AndroidApp/__tests__/App.test.tsx
@@ -4,14 +4,18 @@
 
 import 'react-native';
 import React from 'react';
-import App from '../App';
-
-// Note: import explicitly to use the types shipped with jest.
-import {it} from '@jest/globals';
-
-// Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
+
+jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper');
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+jest.useFakeTimers();
+
+const App = require('../App').default;
 
 it('renders correctly', () => {
   renderer.create(<App />);
 });
+

--- a/AndroidApp/jest.config.js
+++ b/AndroidApp/jest.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   preset: 'react-native',
+  moduleNameMapper: {
+    '\\.(png|jpg|jpeg)$': '<rootDir>/__mocks__/fileMock.js',
+  },
 };

--- a/IOSApp/App.tsx
+++ b/IOSApp/App.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, {useEffect, useRef} from 'react';
 import {NavigationContainer} from '@react-navigation/native';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
-import {View, Text, StyleSheet} from 'react-native';
+import {View, Text, StyleSheet, Animated, Easing} from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import AsyncButton from './src/components/AsyncButton';
 import BACKEND_URL from './src/config';
@@ -13,8 +13,33 @@ function HomeScreen(): React.JSX.Element {
     await AsyncStorage.setItem('lastPress', new Date().toISOString());
   };
 
+  const bounce = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    Animated.loop(
+      Animated.sequence([
+        Animated.timing(bounce, {
+          toValue: -20,
+          duration: 1000,
+          easing: Easing.inOut(Easing.quad),
+          useNativeDriver: true,
+        }),
+        Animated.timing(bounce, {
+          toValue: 0,
+          duration: 1000,
+          easing: Easing.inOut(Easing.quad),
+          useNativeDriver: true,
+        }),
+      ]),
+    ).start();
+  }, [bounce]);
+
   return (
     <View style={styles.container}>
+      <Animated.Image
+        source={require('./src/assets/logo.png')}
+        style={[styles.logo, {transform: [{translateY: bounce}]}]}
+      />
       <Text style={styles.title}>Backend: {BACKEND_URL}</Text>
       <AsyncButton onPress={saveTime}>Save Timestamp</AsyncButton>
     </View>
@@ -36,6 +61,11 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  logo: {
+    width: 100,
+    height: 100,
+    marginBottom: 20,
   },
   title: {
     marginBottom: 16,

--- a/IOSApp/__mocks__/fileMock.js
+++ b/IOSApp/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = '';

--- a/IOSApp/__tests__/App.test.tsx
+++ b/IOSApp/__tests__/App.test.tsx
@@ -4,14 +4,18 @@
 
 import 'react-native';
 import React from 'react';
-import App from '../App';
-
-// Note: import explicitly to use the types shipped with jest.
-import {it} from '@jest/globals';
-
-// Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';
+
+jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper');
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+jest.useFakeTimers();
+
+const App = require('../App').default;
 
 it('renders correctly', () => {
   renderer.create(<App />);
 });
+

--- a/IOSApp/jest.config.js
+++ b/IOSApp/jest.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   preset: 'react-native',
+  moduleNameMapper: {
+    '\\.(png|jpg|jpeg)$': '<rootDir>/__mocks__/fileMock.js',
+  },
 };


### PR DESCRIPTION
## Summary
- add bouncing logo animation to home screen
- configure Jest to mock image assets
- remove bundled logo image to reduce repo size (provide base64 for manual placement)

## Testing
- `cd AndroidApp && npm test` *(fails: ReferenceError: You are trying to import a file after the Jest environment has been torn down)*
- `cd ../IOSApp && npm test` *(fails: TypeError: Cannot read properties of undefined (reading 'loop'))*

------
https://chatgpt.com/codex/tasks/task_e_68c176fd1f508328ab5d554615063e2e