### PR TITLE
Enable updating resource and problem statuses

### DIFF
--- a/codespace/frontend/src/pages/ResourcesPage.js
+++ b/codespace/frontend/src/pages/ResourcesPage.js
@@ -145,7 +145,12 @@ function ResourcesPage() {
 
   const updateStatus = async (id, status) => {
     try {
-      await axios.patch(`${BACKEND_URL}/api/resources/${id}`, { status });
+      const token = localStorage.getItem('token');
+      await axios.patch(
+        `${BACKEND_URL}/api/resources/${id}`,
+        { status },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
       setResources((prev) =>
         prev.map((r) => (r._id === id ? { ...r, status } : r))
       );

--- a/codespace/frontend/src/pages/SectionsPage.js
+++ b/codespace/frontend/src/pages/SectionsPage.js
@@ -80,7 +80,12 @@ function SectionsPage() {
 
   const updateResourceStatus = async (id, status) => {
     try {
-      await axios.patch(`${BACKEND_URL}/api/resources/${id}`, { status });
+      const token = localStorage.getItem('token');
+      await axios.patch(
+        `${BACKEND_URL}/api/resources/${id}`,
+        { status },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
       setResources((prev) =>
         prev.map((r) => (r._id === id ? { ...r, status } : r))
       );
@@ -91,7 +96,12 @@ function SectionsPage() {
 
   const updateProblemStatus = async (id, status) => {
     try {
-      await axios.patch(`${BACKEND_URL}/api/problems/${id}`, { status });
+      const token = localStorage.getItem('token');
+      await axios.patch(
+        `${BACKEND_URL}/api/problems/${id}`,
+        { status },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
       setProblems((prev) =>
         prev.map((p) => (p._id === id ? { ...p, status } : p))
       );


### PR DESCRIPTION
## Summary
- Allow any authenticated user to update resource and problem statuses while restricting other edits to admins
- Send auth tokens when updating statuses in Resources and Sections pages

## Testing
- `npm test` (server)
- `CI=true npm test` (frontend) *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*


------
https://chatgpt.com/codex/tasks/task_e_68c1a67853948328a078ba7e068a908d