### PR TITLE
fix: add auth header for progress update

### DIFF
--- a/codespace/frontend/src/pages/SectionsPage.js
+++ b/codespace/frontend/src/pages/SectionsPage.js
@@ -71,7 +71,12 @@ function SectionsPage() {
   const updateProgress = async (value) => {
     if (!subtopicId) return;
     try {
-      await axios.patch(`${BACKEND_URL}/api/topics/${subtopicId}`, { progress: value });
+      const token = localStorage.getItem('token');
+      await axios.patch(
+        `${BACKEND_URL}/api/topics/${subtopicId}`,
+        { progress: value },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
       setProgress(value);
     } catch (err) {
       console.error('Failed to update progress', err);


### PR DESCRIPTION
## Summary
- include auth header when updating section progress

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*


------
https://chatgpt.com/codex/tasks/task_e_68c1a7f573688328963820a0175866e6