### PR TITLE
Lock reanimated version to fix Pod install

### DIFF
--- a/IOSApp/package.json
+++ b/IOSApp/package.json
@@ -16,7 +16,7 @@
     "react": "18.2.0",
     "react-native": "0.73.6",
     "react-native-gesture-handler": "^2.13.4",
-    "react-native-reanimated": "^3.6.1",
+    "react-native-reanimated": "3.6.1",
     "react-native-safe-area-context": "^4.8.1",
     "react-native-screens": "^3.29.0"
   },


### PR DESCRIPTION
## Summary
- lock react-native-reanimated to 3.6.1 to match React Native 0.73 and avoid pod install errors

## Testing
- `npm test` (fails: Cannot read properties of undefined 'loop')
- `npm run lint` (fails: prettier formatting issues)


------
https://chatgpt.com/codex/tasks/task_e_68c1aa3299588328be45f3298f98d360