### PR TITLE
Add mobile toggle for navbar

### DIFF
--- a/codespace/frontend/src/components/NavBar.js
+++ b/codespace/frontend/src/components/NavBar.js
@@ -17,6 +17,7 @@ function NavBar() {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState([]);
   const [anchorEl, setAnchorEl] = useState(null);
+  const [menuOpen, setMenuOpen] = useState(false);
   const open = Boolean(anchorEl);
   const navigate = useNavigate();
 
@@ -101,6 +102,14 @@ function NavBar() {
     navigate('/login');
   };
 
+  const toggleMenu = () => {
+    setMenuOpen((prev) => !prev);
+  };
+
+  const handleLinkClick = () => {
+    setMenuOpen(false);
+  };
+
   return (
     <nav className="navbar">
       <div className="navbar-brand">
@@ -141,7 +150,14 @@ function NavBar() {
           </div>
         )}
       </div>
-      <ul className="navbar-links">
+      <button
+        className="navbar-toggle"
+        aria-expanded={menuOpen}
+        onClick={toggleMenu}
+      >
+        ☰
+      </button>
+      <ul className={`navbar-links ${menuOpen ? 'open' : ''}`} onClick={handleLinkClick}>
         <li><Link to="/problems">Problems</Link></li>
         <li><Link to="/resources">Resources</Link></li>
         <li><Link to="/sections">Sections</Link></li>

--- a/codespace/frontend/src/styles/NavBar.css
+++ b/codespace/frontend/src/styles/NavBar.css
@@ -64,6 +64,15 @@
   font-weight: bold;
 }
 
+.navbar-toggle {
+  display: none;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
 .navbar-links {
   list-style: none;
   display: flex;
@@ -123,4 +132,31 @@
 
 .profile-button:hover {
   background: rgba(255, 255, 255, 0.2);
+}
+
+@media (max-width: 768px) {
+  .navbar {
+    flex-wrap: wrap;
+  }
+
+  .navbar-links {
+    display: none;
+    flex-direction: column;
+    width: 100%;
+    gap: 1rem;
+    padding: 1rem 0;
+  }
+
+  .navbar-links.open {
+    display: flex;
+  }
+
+  .navbar-toggle {
+    display: block;
+  }
+
+  .navbar-search {
+    width: 100%;
+    margin-top: 0.5rem;
+  }
 }


### PR DESCRIPTION
## Summary
- add menu toggle button and state to navbar
- hide navbar links on mobile and show toggle

## Testing
- `npm test -- --watchAll=false` *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*


------
https://chatgpt.com/codex/tasks/task_e_68c1d44f00048328afd6fbdb5c65806a