### PR TITLE
Fix contest creation missing auth token

### DIFF
--- a/codespace/frontend/src/pages/ContestDetailPage.js
+++ b/codespace/frontend/src/pages/ContestDetailPage.js
@@ -13,6 +13,7 @@ function ContestDetailPage() {
   const [selectedProblem, setSelectedProblem] = useState('');
   const isPastContest = contest && new Date(contest.startTime) <= Date.now();
   const role = localStorage.getItem('role');
+  const token = localStorage.getItem('token');
   const isAdmin = role === 'admin' || role === 'superadmin';
 
   useEffect(() => {
@@ -118,7 +119,10 @@ function ContestDetailPage() {
     try {
       const res = await fetch(`${BACKEND_URL}/api/contests/${id}/problems`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
         body: JSON.stringify({ problem: selectedProblem })
       });
       if (res.ok) {

--- a/codespace/frontend/src/pages/ContestPage.js
+++ b/codespace/frontend/src/pages/ContestPage.js
@@ -41,6 +41,7 @@ function ContestPage() {
   const [form, setForm] = useState({ name: '', startTime: '', duration: '' });
   const userId = localStorage.getItem('userid');
   const role = localStorage.getItem('role');
+  const token = localStorage.getItem('token');
   const isAdmin = role === 'admin' || role === 'superadmin';
 
   const handleInputChange = (e) => {
@@ -88,7 +89,10 @@ function ContestPage() {
     try {
       const res = await fetch(`${BACKEND_URL}/api/contests`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`
+        },
         body: JSON.stringify({
           name: form.name,
           startTime: new Date(form.startTime).toISOString(),


### PR DESCRIPTION
## Summary
- include stored auth token when scheduling new contests
- send token when adding contest problems

## Testing
- `CI=true npm test --silent` (fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')
- `cd codespace/server && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68c1d8d711c88328acb773093f2b45a9