### PR TITLE
feat: add toggle menus for sections

### DIFF
--- a/IOSApp/App.tsx
+++ b/IOSApp/App.tsx
@@ -5,7 +5,9 @@ import {WEB_URL} from './src/config';
 
 export default function App(): React.JSX.Element {
   const [menuVisible, setMenuVisible] = useState(false);
+  const [usExpanded, setUsExpanded] = useState(false);
   const toggleMenu = () => setMenuVisible(prev => !prev);
+  const toggleUS = () => setUsExpanded(prev => !prev);
 
   return (
     <View style={styles.container}>
@@ -32,12 +34,19 @@ export default function App(): React.JSX.Element {
               <Text style={styles.menuItemText}>Close</Text>
             </TouchableOpacity>
             <Text style={styles.sectionHeader}>Sections</Text>
-            <TouchableOpacity style={styles.subItem}>
-              <Text style={styles.subItemText}>Problems</Text>
+            <TouchableOpacity onPress={toggleUS} style={styles.menuItem}>
+              <Text style={styles.menuItemText}>US {usExpanded ? '-' : '+'}</Text>
             </TouchableOpacity>
-            <TouchableOpacity style={styles.subItem}>
-              <Text style={styles.subItemText}>Resources</Text>
-            </TouchableOpacity>
+            {usExpanded && (
+              <>
+                <TouchableOpacity style={styles.subItem}>
+                  <Text style={styles.subItemText}>Problems</Text>
+                </TouchableOpacity>
+                <TouchableOpacity style={styles.subItem}>
+                  <Text style={styles.subItemText}>Resources</Text>
+                </TouchableOpacity>
+              </>
+            )}
           </View>
         </View>
       </Modal>

--- a/codespace/frontend/src/components/NavBar.js
+++ b/codespace/frontend/src/components/NavBar.js
@@ -18,6 +18,7 @@ function NavBar() {
   const [searchResults, setSearchResults] = useState([]);
   const [anchorEl, setAnchorEl] = useState(null);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [usOpen, setUsOpen] = useState(false);
   const open = Boolean(anchorEl);
   const navigate = useNavigate();
 
@@ -108,6 +109,12 @@ function NavBar() {
 
   const handleLinkClick = () => {
     setMenuOpen(false);
+    setUsOpen(false);
+  };
+
+  const toggleUS = (e) => {
+    e.stopPropagation();
+    setUsOpen((prev) => !prev);
   };
 
   return (
@@ -158,8 +165,17 @@ function NavBar() {
         ☰
       </button>
       <ul className={`navbar-links ${menuOpen ? 'open' : ''}`} onClick={handleLinkClick}>
-        <li><Link to="/problems">Problems</Link></li>
-        <li><Link to="/resources">Resources</Link></li>
+        <li className="dropdown">
+          <button className="dropdown-toggle" onClick={toggleUS}>
+            US {usOpen ? '-' : '+'}
+          </button>
+          {usOpen && (
+            <ul className="dropdown-menu">
+              <li><Link to="/problems">Problems</Link></li>
+              <li><Link to="/resources">Resources</Link></li>
+            </ul>
+          )}
+        </li>
         <li><Link to="/sections">Sections</Link></li>
         <li><Link to="/contests">Contests</Link></li>
         <li><Link to="/rooms">Rooms</Link></li>

--- a/codespace/frontend/src/pages/SectionsPage.js
+++ b/codespace/frontend/src/pages/SectionsPage.js
@@ -25,6 +25,7 @@ function SectionsPage() {
   const [resources, setResources] = useState([]);
   const [problems, setProblems] = useState([]);
   const [progress, setProgress] = useState('not started');
+  const [sidebarOpen, setSidebarOpen] = useState(true);
 
   useEffect(() => {
     const fetchTopics = async () => {
@@ -126,14 +127,18 @@ function SectionsPage() {
   return (
     <div>
       <NavBar />
+      <button className="sidebar-toggle" onClick={() => setSidebarOpen((prev) => !prev)}>
+        Sections {sidebarOpen ? '-' : '+'}
+      </button>
       <div className="sections-page">
-        <div className="sections-sidebar">
-          <FormControl fullWidth className="stage-select">
-            <InputLabel id="stage-select-label">Stage</InputLabel>
-            <Select
-              labelId="stage-select-label"
-              value={stageFilter}
-              label="Stage"
+        {sidebarOpen && (
+          <div className="sections-sidebar">
+            <FormControl fullWidth className="stage-select">
+              <InputLabel id="stage-select-label">Stage</InputLabel>
+              <Select
+                labelId="stage-select-label"
+                value={stageFilter}
+                label="Stage"
               onChange={(e) => {
                 setStageFilter(e.target.value);
                 setSelectedTopic(null);
@@ -147,31 +152,32 @@ function SectionsPage() {
               ))}
             </Select>
           </FormControl>
-          <div className="topics-list">
-            {Object.keys(topics[stageFilter] || {}).map((t) => (
-              <div key={t} className="topic-item">
-                <div className="topic-name">{t}</div>
-                <ul>
-                  {topics[stageFilter][t].map((sub) => (
-                    <li
-                      key={sub._id}
-                      className={
-                        selectedStage === stageFilter &&
-                        selectedTopic === t &&
-                        selectedSubtopic === sub.subtopic
-                          ? 'selected'
-                          : ''
-                      }
-                      onClick={() => loadContent(stageFilter, t, sub)}
-                    >
-                      {sub.subtopic}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ))}
+            <div className="topics-list">
+              {Object.keys(topics[stageFilter] || {}).map((t) => (
+                <div key={t} className="topic-item">
+                  <div className="topic-name">{t}</div>
+                  <ul>
+                    {topics[stageFilter][t].map((sub) => (
+                      <li
+                        key={sub._id}
+                        className={
+                          selectedStage === stageFilter &&
+                          selectedTopic === t &&
+                          selectedSubtopic === sub.subtopic
+                            ? 'selected'
+                            : ''
+                        }
+                        onClick={() => loadContent(stageFilter, t, sub)}
+                      >
+                        {sub.subtopic}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
           </div>
-        </div>
+        )}
         <div className="sections-content">
           {selectedSubtopic ? (
             <div>

--- a/codespace/frontend/src/styles/NavBar.css
+++ b/codespace/frontend/src/styles/NavBar.css
@@ -109,6 +109,28 @@
   width: 100%;
 }
 
+.dropdown {
+  position: relative;
+}
+
+.dropdown-toggle {
+  background: none;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+  font: inherit;
+}
+
+.dropdown-menu {
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem 0;
+}
+
+.dropdown-menu li {
+  margin: 0;
+}
+
 .profile-container {
   position: relative;
 }

--- a/codespace/frontend/src/styles/SectionsPage.css
+++ b/codespace/frontend/src/styles/SectionsPage.css
@@ -3,6 +3,10 @@
   height: calc(100vh - 60px);
 }
 
+.sidebar-toggle {
+  margin: 1rem;
+}
+
 .sections-sidebar {
   width: 250px;
   border-right: 1px solid #ccc;


### PR DESCRIPTION
## Summary
- make sidebar sections collapsible in React Native app
- group Problems and Resources under a US dropdown in NavBar
- add toggle to show/hide sections sidebar on web

## Testing
- `npm test`
- `npm test -- --watchAll=false` *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*


------
https://chatgpt.com/codex/tasks/task_e_68c1dbcbed288328a9a618881c682c0a