### PR TITLE
Rename project to CodeSpace and update icon references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Software-Graduation-Project
+# CodeSpace
 
 ## Local test data storage
 

--- a/codespace/frontend/public/index.html
+++ b/codespace/frontend/public/index.html
@@ -2,14 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="icon" href="%PUBLIC_URL%/codespace-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, viewport-fit=cover" />
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
       content="Web site created using create-react-app"
     />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link rel="apple-touch-icon" href="%PUBLIC_URL%/codespace-192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
@@ -20,11 +20,11 @@
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
 
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
+      Unlike "/codespace-icon.png" or "codespace-icon.png", "%PUBLIC_URL%/codespace-icon.png" will
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Code Hub</title>
+    <title>CodeSpace</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/codespace/frontend/public/manifest.json
+++ b/codespace/frontend/public/manifest.json
@@ -1,19 +1,19 @@
 {
-  "short_name": "Code Hub",
-  "name": "Code Hub",
+  "short_name": "CodeSpace",
+  "name": "CodeSpace",
   "icons": [
     {
-      "src": "favicon.ico",
+      "src": "codespace-icon.png",
       "sizes": "64x64 32x32 24x24 16x16",
-      "type": "image/x-icon"
+      "type": "image/png"
     },
     {
-      "src": "logo192.png",
+      "src": "codespace-192.png",
       "type": "image/png",
       "sizes": "192x192"
     },
     {
-      "src": "logo512.png",
+      "src": "codespace-512.png",
       "type": "image/png",
       "sizes": "512x512"
     }

--- a/codespace/frontend/src/components/NavBar.js
+++ b/codespace/frontend/src/components/NavBar.js
@@ -114,8 +114,8 @@ function NavBar() {
     <nav className="navbar">
       <div className="navbar-brand">
         <Link to="/" className="brand-link">
-          <img src={logo} alt="Code Hub logo" className="brand-logo" />
-          <span className="brand-name">Code Hub</span>
+          <img src={logo} alt="CodeSpace logo" className="brand-logo" />
+          <span className="brand-name">CodeSpace</span>
         </Link>
       </div>
       <div className="navbar-search">

--- a/codespace/frontend/src/pages/HomePage.js
+++ b/codespace/frontend/src/pages/HomePage.js
@@ -9,7 +9,7 @@ function HomePage() {
     <div className="home-container">
       <NavBar />
       <main className="home-hero">
-        <h1 className="home-title">Code Hub</h1>
+        <h1 className="home-title">CodeSpace</h1>
         <p className="home-tagline">A free collection of curated, high-quality resources</p>
         <p className="home-tagline">to take you from Bronze to Platinum and beyond.</p>
       </main>


### PR DESCRIPTION
## Summary
- rename site title and brand references from Code Hub to CodeSpace
- point favicon and manifest to new CodeSpace icons
- document project as CodeSpace

## Testing
- `CI=true npm test -- --watchAll=false` *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*

------
https://chatgpt.com/codex/tasks/task_e_68c1e3bd3280832895866350f6ccf00b