### PR TITLE
feat(home): add compact features overview with image placeholders

### DIFF
--- a/codespace/frontend/README.md
+++ b/codespace/frontend/README.md
@@ -75,3 +75,13 @@ This section has moved here: [https://facebook.github.io/create-react-app/docs/d
 ### `npm run build` fails to minify
 
 This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+
+## Image placeholders
+
+The Home page references the following placeholder images. Add them later under `frontend/public/images/`:
+
+- `feature_problems.jpg`
+- `feature_resources.jpg`
+- `feature_sections.jpg`
+- `feature_contests.jpg`
+- `feature_rooms.jpg`

--- a/codespace/frontend/src/pages/HomePage.js
+++ b/codespace/frontend/src/pages/HomePage.js
@@ -1,17 +1,97 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import NavBar from '../components/NavBar';
 import '../styles/HomePage.css';
-import architectureImg from '../assets/images/architecture.png';
-import awwImg from '../assets/images/aww.png';
+
+const features = [
+  {
+    title: 'Problems',
+    description:
+      'Solve curated challenges with instant feedback. Track progress and learn from clear explanations.',
+    bullets: ['Difficulty tiers', 'Hints/editorials'],
+    image: '/images/feature_problems.jpg',
+    alt: 'Students solving coding problems in an online editor.',
+    link: '/problems',
+  },
+  {
+    title: 'Resources',
+    description: 'Guides, templates, and walkthroughs to help you move faster.',
+    bullets: ['Topic roadmaps', 'Cheat sheets'],
+    image: '/images/feature_resources.jpg',
+    alt: 'Laptop with documentation and notes beside a stack of books.',
+    link: '/resources',
+  },
+  {
+    title: 'Sections',
+    description:
+      'Structured learning paths—algorithms, data structures, competitive prep, and more.',
+    bullets: ['Progress tracking', 'Next steps'],
+    image: '/images/feature_sections.jpg',
+    alt: 'Dashboard UI showing categorized learning tiles.',
+    link: '/sections',
+  },
+  {
+    title: 'Contests',
+    description:
+      'Join timed contests, climb the leaderboard, and learn from post-contest editorials.',
+    bullets: ['Live timer', 'Scoreboard'],
+    image: '/images/feature_contests.jpg',
+    alt: 'Trophy beside a digital scoreboard.',
+    link: '/contests',
+  },
+  {
+    title: 'Rooms',
+    description:
+      'Study with friends—share problems, compare solutions, and stay motivated.',
+    bullets: ['Invite links', 'Shared sets'],
+    image: '/images/feature_rooms.jpg',
+    alt: 'Group collaborating around laptops / grid of video call tiles.',
+    link: '/rooms',
+  },
+];
 
 function HomePage() {
   return (
     <div className="home-container">
       <NavBar />
-      <main className="home-hero">
-        <h1 className="home-title">CodeSpace</h1>
-        <p className="home-tagline">A free collection of curated, high-quality resources</p>
-        <p className="home-tagline">to take you from Bronze to Platinum and beyond.</p>
+      <main>
+        <section className="home-hero">
+          <h1 className="home-title">Practice. Compete. Grow.</h1>
+          <p className="home-tagline">
+            From bite-sized problems to full contests and study rooms—everything you need to level
+            up.
+          </p>
+          <div className="hero-buttons">
+            <Link to="/signup" className="hero-button">
+              Get Started
+            </Link>
+            <Link to="/contests" className="hero-button secondary">
+              Explore Contests
+            </Link>
+          </div>
+        </section>
+        <section className="features-overview">
+          <h2>What you'll find</h2>
+          <div className="features-grid">
+            {features.map((f) => (
+              <article key={f.title} className="feature-card">
+                <img src={f.image} alt={f.alt} />
+                <h3>{f.title}</h3>
+                <p>{f.description}</p>
+                <ul>
+                  {f.bullets.map((b) => (
+                    <li key={b}>{b}</li>
+                  ))}
+                </ul>
+                {f.link && (
+                  <Link to={f.link} className="feature-link">
+                    Open →
+                  </Link>
+                )}
+              </article>
+            ))}
+          </div>
+        </section>
       </main>
       <footer className="home-footer">Created by the CP Initiative</footer>
     </div>

--- a/codespace/frontend/src/styles/HomePage.css
+++ b/codespace/frontend/src/styles/HomePage.css
@@ -15,7 +15,7 @@
   color: #fff;
   background: linear-gradient(-45deg, #ff9a9e, #fad0c4, #fbc2eb, #a1c4fd);
   background-size: 400% 400%;
-  padding: 0 1rem;
+  padding: 0 1rem 3rem;
 }
 
 .home-title {
@@ -31,23 +31,69 @@
   color: #fafafa;
 }
 
-.home-gallery {
+.hero-buttons {
   display: flex;
-  justify-content: center;
   gap: 1rem;
+  margin-top: 1.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.hero-button {
+  display: inline-block;
+  padding: 0.75rem 1.25rem;
+  background-color: #ffffff;
+  color: #333;
+  border-radius: 4px;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.hero-button.secondary {
+  background-color: rgba(255, 255, 255, 0.85);
+}
+
+.features-overview {
   padding: 2rem 1rem;
   background-color: #fff;
+  text-align: center;
 }
 
-.gallery-image {
-  width: 150px;
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.feature-card {
+  background-color: #fff;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  transition: transform 0.3s ease;
+  padding: 1rem;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
 }
 
-.gallery-image:hover {
-  transform: scale(1.05);
+.feature-card img {
+  width: 100%;
+  border-radius: 4px;
+}
+
+.feature-card h3 {
+  margin: 0.5rem 0;
+}
+
+.feature-card ul {
+  margin: 0.5rem 0 0.5rem 1.25rem;
+}
+
+.feature-link {
+  margin-top: auto;
+  text-decoration: none;
+  color: #0077cc;
+  font-weight: 600;
 }
 
 @keyframes gradientBG {


### PR DESCRIPTION
## Summary
- revamp home hero with welcoming tagline and signup/contest CTAs
- add "What you'll find" grid showcasing problems, resources, sections, contests, and rooms with image placeholders
- document placeholder image filenames for later placement

## Testing
- `npm test -- --watchAll=false` (fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')

------
https://chatgpt.com/codex/tasks/task_e_68c1ede1a4a48328bf72bf5ccbce3f0f