### PR TITLE
Fix auth for resource/problem creation and modernize dropdowns

### DIFF
--- a/codespace/frontend/src/components/ProblemSidebar.js
+++ b/codespace/frontend/src/components/ProblemSidebar.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FormControl, InputLabel, MenuItem, Select } from '@mui/material';
 
 function ProblemSidebar({
   showForm,
@@ -52,79 +53,97 @@ function ProblemSidebar({
                 onChange={handleFormChange}
                 required
               />
-              <select
-                name="stage"
-                value={formData.stage}
-                onChange={handleFormChange}
-                required
-              >
-                <option value="">Select Stage</option>
-                {['Bronze', 'Silver', 'Gold'].map((s) => (
-                  <option key={s} value={s}>
-                    {s}
-                  </option>
-                ))}
-              </select>
-              <select
-                name="topic"
-                value={formData.topic}
-                onChange={handleFormChange}
-                disabled={!formData.stage}
-                required
-              >
-                <option value="">Select Topic</option>
-                {formData.stage &&
-                  Object.keys(topics[formData.stage] || {}).map((topic) => (
-                    <option key={topic} value={topic}>
-                      {topic}
-                    </option>
+              <FormControl fullWidth size="small">
+                <InputLabel id="problem-stage-label">Stage</InputLabel>
+                <Select
+                  labelId="problem-stage-label"
+                  name="stage"
+                  value={formData.stage}
+                  label="Stage"
+                  onChange={handleFormChange}
+                  required
+                >
+                  {['Bronze', 'Silver', 'Gold'].map((s) => (
+                    <MenuItem key={s} value={s}>
+                      {s}
+                    </MenuItem>
                   ))}
-              </select>
-              <select
-                name="subtopic"
-                value={formData.subtopic}
-                onChange={handleFormChange}
-                disabled={!formData.topic}
-                required
-              >
-                <option value="">Select Subtopic</option>
-                {formData.stage &&
-                  formData.topic &&
-                  topics[formData.stage][formData.topic].map((sub) => (
-                    <option key={sub} value={sub}>
-                      {sub}
-                    </option>
-                  ))}
-              </select>
-              <select
-                name="difficulty"
-                value={formData.difficulty}
-                onChange={handleFormChange}
-                required
-              >
-                <option value="">Select Difficulty</option>
-                <option value="Easy">Easy</option>
-                <option value="Medium">Medium</option>
-                <option value="Hard">Hard</option>
-                <option value="Insane">Insane</option>
-              </select>
+                </Select>
+              </FormControl>
+              <FormControl fullWidth size="small" disabled={!formData.stage}>
+                <InputLabel id="problem-topic-label">Topic</InputLabel>
+                <Select
+                  labelId="problem-topic-label"
+                  name="topic"
+                  value={formData.topic}
+                  label="Topic"
+                  onChange={handleFormChange}
+                  required
+                >
+                  {formData.stage &&
+                    Object.keys(topics[formData.stage] || {}).map((topic) => (
+                      <MenuItem key={topic} value={topic}>
+                        {topic}
+                      </MenuItem>
+                    ))}
+                </Select>
+              </FormControl>
+              <FormControl fullWidth size="small" disabled={!formData.topic}>
+                <InputLabel id="problem-subtopic-label">Subtopic</InputLabel>
+                <Select
+                  labelId="problem-subtopic-label"
+                  name="subtopic"
+                  value={formData.subtopic}
+                  label="Subtopic"
+                  onChange={handleFormChange}
+                  required
+                >
+                  {formData.stage &&
+                    formData.topic &&
+                    topics[formData.stage][formData.topic].map((sub) => (
+                      <MenuItem key={sub} value={sub}>
+                        {sub}
+                      </MenuItem>
+                    ))}
+                </Select>
+              </FormControl>
+              <FormControl fullWidth size="small">
+                <InputLabel id="problem-difficulty-label">Difficulty</InputLabel>
+                <Select
+                  labelId="problem-difficulty-label"
+                  name="difficulty"
+                  value={formData.difficulty}
+                  label="Difficulty"
+                  onChange={handleFormChange}
+                  required
+                >
+                  <MenuItem value="Easy">Easy</MenuItem>
+                  <MenuItem value="Medium">Medium</MenuItem>
+                  <MenuItem value="Hard">Hard</MenuItem>
+                  <MenuItem value="Insane">Insane</MenuItem>
+                </Select>
+              </FormControl>
               <button type="submit">Add</button>
             </form>
           )}
           {showTopicForm && (
             <form className="add-topic-form" onSubmit={addTopic}>
-              <select
-                value={newTopic.stage}
-                onChange={(e) => setNewTopic((prev) => ({ ...prev, stage: e.target.value }))}
-                required
-              >
-                <option value="">Select Stage</option>
-                {['Bronze', 'Silver', 'Gold'].map((s) => (
-                  <option key={s} value={s}>
-                    {s}
-                  </option>
-                ))}
-              </select>
+              <FormControl fullWidth size="small">
+                <InputLabel id="topic-stage-label">Stage</InputLabel>
+                <Select
+                  labelId="topic-stage-label"
+                  value={newTopic.stage}
+                  label="Stage"
+                  onChange={(e) => setNewTopic((prev) => ({ ...prev, stage: e.target.value }))}
+                  required
+                >
+                  {['Bronze', 'Silver', 'Gold'].map((s) => (
+                    <MenuItem key={s} value={s}>
+                      {s}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
               <input
                 type="text"
                 value={newTopic.name}
@@ -137,32 +156,41 @@ function ProblemSidebar({
           )}
           {showSubtopicForm && (
             <form className="add-subtopic-form" onSubmit={addSubtopic}>
-              <select
-                value={newSubtopic.stage}
-                onChange={(e) => setNewSubtopic((prev) => ({ ...prev, stage: e.target.value, topic: '' }))}
-                required
-              >
-                <option value="">Select Stage</option>
-                {['Bronze', 'Silver', 'Gold'].map((s) => (
-                  <option key={s} value={s}>
-                    {s}
-                  </option>
-                ))}
-              </select>
-              <select
-                value={newSubtopic.topic}
-                onChange={(e) => setNewSubtopic((prev) => ({ ...prev, topic: e.target.value }))}
-                disabled={!newSubtopic.stage}
-                required
-              >
-                <option value="">Select Topic</option>
-                {newSubtopic.stage &&
-                  Object.keys(topics[newSubtopic.stage] || {}).map((topic) => (
-                    <option key={topic} value={topic}>
-                      {topic}
-                    </option>
+              <FormControl fullWidth size="small">
+                <InputLabel id="subtopic-stage-label">Stage</InputLabel>
+                <Select
+                  labelId="subtopic-stage-label"
+                  value={newSubtopic.stage}
+                  label="Stage"
+                  onChange={(e) =>
+                    setNewSubtopic((prev) => ({ ...prev, stage: e.target.value, topic: '' }))
+                  }
+                  required
+                >
+                  {['Bronze', 'Silver', 'Gold'].map((s) => (
+                    <MenuItem key={s} value={s}>
+                      {s}
+                    </MenuItem>
                   ))}
-              </select>
+                </Select>
+              </FormControl>
+              <FormControl fullWidth size="small" disabled={!newSubtopic.stage}>
+                <InputLabel id="subtopic-topic-label">Topic</InputLabel>
+                <Select
+                  labelId="subtopic-topic-label"
+                  value={newSubtopic.topic}
+                  label="Topic"
+                  onChange={(e) => setNewSubtopic((prev) => ({ ...prev, topic: e.target.value }))}
+                  required
+                >
+                  {newSubtopic.stage &&
+                    Object.keys(topics[newSubtopic.stage] || {}).map((topic) => (
+                      <MenuItem key={topic} value={topic}>
+                        {topic}
+                      </MenuItem>
+                    ))}
+                </Select>
+              </FormControl>
               <input
                 type="text"
                 value={newSubtopic.name}
@@ -175,37 +203,59 @@ function ProblemSidebar({
           )}
         </>
       )}
-      <select value={selectedStage} onChange={handleStageChange}>
-        <option value="">All Stages</option>
-        {['Bronze', 'Silver', 'Gold'].map((s) => (
-          <option key={s} value={s}>
-            {s}
-          </option>
-        ))}
-      </select>
-      <select value={selectedTopic} onChange={handleTopicChange} disabled={!selectedStage}>
-        <option value="">All Topics</option>
-        {selectedStage &&
-          Object.keys(topics[selectedStage] || {}).map((topic) => (
-            <option key={topic} value={topic}>
-              {topic}
-            </option>
+      <FormControl fullWidth size="small">
+        <InputLabel id="filter-stage-label">Stage</InputLabel>
+        <Select
+          labelId="filter-stage-label"
+          value={selectedStage}
+          label="Stage"
+          onChange={handleStageChange}
+        >
+          <MenuItem value="">All Stages</MenuItem>
+          {['Bronze', 'Silver', 'Gold'].map((s) => (
+            <MenuItem key={s} value={s}>
+              {s}
+            </MenuItem>
           ))}
-      </select>
-      <select
-        value={selectedSubtopic}
-        onChange={(e) => setSelectedSubtopic(e.target.value)}
-        disabled={!selectedTopic}
-      >
-        <option value="">All Subtopics</option>
-        {selectedStage &&
-          selectedTopic &&
-          topics[selectedStage][selectedTopic].map((sub) => (
-            <option key={sub} value={sub}>
-              {sub}
-            </option>
-          ))}
-      </select>
+        </Select>
+      </FormControl>
+      <FormControl fullWidth size="small" disabled={!selectedStage}>
+        <InputLabel id="filter-topic-label">Topic</InputLabel>
+        <Select
+          labelId="filter-topic-label"
+          value={selectedTopic}
+          label="Topic"
+          onChange={handleTopicChange}
+          disabled={!selectedStage}
+        >
+          <MenuItem value="">All Topics</MenuItem>
+          {selectedStage &&
+            Object.keys(topics[selectedStage] || {}).map((topic) => (
+              <MenuItem key={topic} value={topic}>
+                {topic}
+              </MenuItem>
+            ))}
+        </Select>
+      </FormControl>
+      <FormControl fullWidth size="small" disabled={!selectedTopic}>
+        <InputLabel id="filter-subtopic-label">Subtopic</InputLabel>
+        <Select
+          labelId="filter-subtopic-label"
+          value={selectedSubtopic}
+          label="Subtopic"
+          onChange={(e) => setSelectedSubtopic(e.target.value)}
+          disabled={!selectedTopic}
+        >
+          <MenuItem value="">All Subtopics</MenuItem>
+          {selectedStage &&
+            selectedTopic &&
+            topics[selectedStage][selectedTopic].map((sub) => (
+              <MenuItem key={sub} value={sub}>
+                {sub}
+              </MenuItem>
+            ))}
+        </Select>
+      </FormControl>
     </div>
   );
 }

--- a/codespace/frontend/src/components/ResourcesSidebar.js
+++ b/codespace/frontend/src/components/ResourcesSidebar.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FormControl, InputLabel, MenuItem, Select } from '@mui/material';
 
 function ResourcesSidebar({
   showForm,
@@ -52,67 +53,81 @@ function ResourcesSidebar({
                 onChange={handleFormChange}
                 required
               />
-              <select
-                name="stage"
-                value={formData.stage}
-                onChange={handleFormChange}
-                required
-              >
-                <option value="">Select Stage</option>
-                {['Bronze', 'Silver', 'Gold'].map((s) => (
-                  <option key={s} value={s}>
-                    {s}
-                  </option>
-                ))}
-              </select>
-              <select
-                name="topic"
-                value={formData.topic}
-                onChange={handleFormChange}
-                disabled={!formData.stage}
-                required
-              >
-                <option value="">Select Topic</option>
-                {formData.stage &&
-                  Object.keys(topics[formData.stage] || {}).map((topic) => (
-                    <option key={topic} value={topic}>
-                      {topic}
-                    </option>
+              <FormControl fullWidth size="small">
+                <InputLabel id="resource-stage-label">Stage</InputLabel>
+                <Select
+                  labelId="resource-stage-label"
+                  name="stage"
+                  value={formData.stage}
+                  label="Stage"
+                  onChange={handleFormChange}
+                  required
+                >
+                  {['Bronze', 'Silver', 'Gold'].map((s) => (
+                    <MenuItem key={s} value={s}>
+                      {s}
+                    </MenuItem>
                   ))}
-              </select>
-              <select
-                name="subtopic"
-                value={formData.subtopic}
-                onChange={handleFormChange}
-                disabled={!formData.topic}
-                required
-              >
-                <option value="">Select Subtopic</option>
-                {formData.stage &&
-                  formData.topic &&
-                  topics[formData.stage][formData.topic].map((sub) => (
-                    <option key={sub} value={sub}>
-                      {sub}
-                    </option>
-                  ))}
-              </select>
+                </Select>
+              </FormControl>
+              <FormControl fullWidth size="small" disabled={!formData.stage}>
+                <InputLabel id="resource-topic-label">Topic</InputLabel>
+                <Select
+                  labelId="resource-topic-label"
+                  name="topic"
+                  value={formData.topic}
+                  label="Topic"
+                  onChange={handleFormChange}
+                  required
+                >
+                  {formData.stage &&
+                    Object.keys(topics[formData.stage] || {}).map((topic) => (
+                      <MenuItem key={topic} value={topic}>
+                        {topic}
+                      </MenuItem>
+                    ))}
+                </Select>
+              </FormControl>
+              <FormControl fullWidth size="small" disabled={!formData.topic}>
+                <InputLabel id="resource-subtopic-label">Subtopic</InputLabel>
+                <Select
+                  labelId="resource-subtopic-label"
+                  name="subtopic"
+                  value={formData.subtopic}
+                  label="Subtopic"
+                  onChange={handleFormChange}
+                  required
+                >
+                  {formData.stage &&
+                    formData.topic &&
+                    topics[formData.stage][formData.topic].map((sub) => (
+                      <MenuItem key={sub} value={sub}>
+                        {sub}
+                      </MenuItem>
+                    ))}
+                </Select>
+              </FormControl>
               <button type="submit">Add</button>
             </form>
           )}
           {showTopicForm && (
             <form className="add-topic-form" onSubmit={addTopic}>
-              <select
-                value={newTopic.stage}
-                onChange={(e) => setNewTopic((prev) => ({ ...prev, stage: e.target.value }))}
-                required
-              >
-                <option value="">Select Stage</option>
-                {['Bronze', 'Silver', 'Gold'].map((s) => (
-                  <option key={s} value={s}>
-                    {s}
-                  </option>
-                ))}
-              </select>
+              <FormControl fullWidth size="small">
+                <InputLabel id="topic-stage-label">Stage</InputLabel>
+                <Select
+                  labelId="topic-stage-label"
+                  value={newTopic.stage}
+                  label="Stage"
+                  onChange={(e) => setNewTopic((prev) => ({ ...prev, stage: e.target.value }))}
+                  required
+                >
+                  {['Bronze', 'Silver', 'Gold'].map((s) => (
+                    <MenuItem key={s} value={s}>
+                      {s}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
               <input
                 type="text"
                 value={newTopic.name}
@@ -125,32 +140,43 @@ function ResourcesSidebar({
           )}
           {showSubtopicForm && (
             <form className="add-subtopic-form" onSubmit={addSubtopic}>
-              <select
-                value={newSubtopic.stage}
-                onChange={(e) => setNewSubtopic((prev) => ({ ...prev, stage: e.target.value, topic: '' }))}
-                required
-              >
-                <option value="">Select Stage</option>
-                {['Bronze', 'Silver', 'Gold'].map((s) => (
-                  <option key={s} value={s}>
-                    {s}
-                  </option>
-                ))}
-              </select>
-              <select
-                value={newSubtopic.topic}
-                onChange={(e) => setNewSubtopic((prev) => ({ ...prev, topic: e.target.value }))}
-                disabled={!newSubtopic.stage}
-                required
-              >
-                <option value="">Select Topic</option>
-                {newSubtopic.stage &&
-                  Object.keys(topics[newSubtopic.stage] || {}).map((topic) => (
-                    <option key={topic} value={topic}>
-                      {topic}
-                    </option>
+              <FormControl fullWidth size="small">
+                <InputLabel id="subtopic-stage-label">Stage</InputLabel>
+                <Select
+                  labelId="subtopic-stage-label"
+                  value={newSubtopic.stage}
+                  label="Stage"
+                  onChange={(e) =>
+                    setNewSubtopic((prev) => ({ ...prev, stage: e.target.value, topic: '' }))
+                  }
+                  required
+                >
+                  {['Bronze', 'Silver', 'Gold'].map((s) => (
+                    <MenuItem key={s} value={s}>
+                      {s}
+                    </MenuItem>
                   ))}
-              </select>
+                </Select>
+              </FormControl>
+              <FormControl fullWidth size="small" disabled={!newSubtopic.stage}>
+                <InputLabel id="subtopic-topic-label">Topic</InputLabel>
+                <Select
+                  labelId="subtopic-topic-label"
+                  value={newSubtopic.topic}
+                  label="Topic"
+                  onChange={(e) =>
+                    setNewSubtopic((prev) => ({ ...prev, topic: e.target.value }))
+                  }
+                  required
+                >
+                  {newSubtopic.stage &&
+                    Object.keys(topics[newSubtopic.stage] || {}).map((topic) => (
+                      <MenuItem key={topic} value={topic}>
+                        {topic}
+                      </MenuItem>
+                    ))}
+                </Select>
+              </FormControl>
               <input
                 type="text"
                 value={newSubtopic.name}
@@ -163,37 +189,59 @@ function ResourcesSidebar({
           )}
         </>
       )}
-      <select value={selectedStage} onChange={handleStageChange}>
-        <option value="">All Stages</option>
-        {['Bronze', 'Silver', 'Gold'].map((s) => (
-          <option key={s} value={s}>
-            {s}
-          </option>
-        ))}
-      </select>
-      <select value={selectedTopic} onChange={handleTopicChange} disabled={!selectedStage}>
-        <option value="">All Topics</option>
-        {selectedStage &&
-          Object.keys(topics[selectedStage] || {}).map((topic) => (
-            <option key={topic} value={topic}>
-              {topic}
-            </option>
+      <FormControl fullWidth size="small">
+        <InputLabel id="filter-stage-label">Stage</InputLabel>
+        <Select
+          labelId="filter-stage-label"
+          value={selectedStage}
+          label="Stage"
+          onChange={handleStageChange}
+        >
+          <MenuItem value="">All Stages</MenuItem>
+          {['Bronze', 'Silver', 'Gold'].map((s) => (
+            <MenuItem key={s} value={s}>
+              {s}
+            </MenuItem>
           ))}
-      </select>
-      <select
-        value={selectedSubtopic}
-        onChange={(e) => setSelectedSubtopic(e.target.value)}
-        disabled={!selectedTopic}
-      >
-        <option value="">All Subtopics</option>
-        {selectedStage &&
-          selectedTopic &&
-          topics[selectedStage][selectedTopic].map((sub) => (
-            <option key={sub} value={sub}>
-              {sub}
-            </option>
-          ))}
-      </select>
+        </Select>
+      </FormControl>
+      <FormControl fullWidth size="small" disabled={!selectedStage}>
+        <InputLabel id="filter-topic-label">Topic</InputLabel>
+        <Select
+          labelId="filter-topic-label"
+          value={selectedTopic}
+          label="Topic"
+          onChange={handleTopicChange}
+          disabled={!selectedStage}
+        >
+          <MenuItem value="">All Topics</MenuItem>
+          {selectedStage &&
+            Object.keys(topics[selectedStage] || {}).map((topic) => (
+              <MenuItem key={topic} value={topic}>
+                {topic}
+              </MenuItem>
+            ))}
+        </Select>
+      </FormControl>
+      <FormControl fullWidth size="small" disabled={!selectedTopic}>
+        <InputLabel id="filter-subtopic-label">Subtopic</InputLabel>
+        <Select
+          labelId="filter-subtopic-label"
+          value={selectedSubtopic}
+          label="Subtopic"
+          onChange={(e) => setSelectedSubtopic(e.target.value)}
+          disabled={!selectedTopic}
+        >
+          <MenuItem value="">All Subtopics</MenuItem>
+          {selectedStage &&
+            selectedTopic &&
+            topics[selectedStage][selectedTopic].map((sub) => (
+              <MenuItem key={sub} value={sub}>
+                {sub}
+              </MenuItem>
+            ))}
+        </Select>
+      </FormControl>
     </div>
   );
 }

--- a/codespace/frontend/src/pages/ProblemsPage.js
+++ b/codespace/frontend/src/pages/ProblemsPage.js
@@ -89,7 +89,12 @@ function ProblemsPage() {
     const { stage, name } = newTopic;
     if (!stage || !name) return;
     try {
-      await axios.post(`${BACKEND_URL}/api/topics`, { stage, topic: name });
+      const token = localStorage.getItem('token');
+      await axios.post(
+        `${BACKEND_URL}/api/topics`,
+        { stage, topic: name },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
       setTopics((prev) => ({
         ...prev,
         [stage]: { ...(prev[stage] || {}), [name]: [] },
@@ -107,7 +112,12 @@ function ProblemsPage() {
     const { stage, topic, name } = newSubtopic;
     if (!stage || !topic || !name) return;
     try {
-      await axios.post(`${BACKEND_URL}/api/topics`, { stage, topic, subtopic: name });
+      const token = localStorage.getItem('token');
+      await axios.post(
+        `${BACKEND_URL}/api/topics`,
+        { stage, topic, subtopic: name },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
       setTopics((prev) => ({
         ...prev,
         [stage]: {
@@ -126,7 +136,12 @@ function ProblemsPage() {
     e.preventDefault();
     if (!isAdmin) return;
     try {
-      const res = await axios.post(`${BACKEND_URL}/api/problems`, formData);
+      const token = localStorage.getItem('token');
+      const res = await axios.post(
+        `${BACKEND_URL}/api/problems`,
+        formData,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
       setProblems((prev) => [...prev, res.data]);
       setFormData({ name: '', link: '', stage: '', topic: '', subtopic: '', difficulty: '' });
       setShowForm(false);

--- a/codespace/frontend/src/pages/ResourcesPage.js
+++ b/codespace/frontend/src/pages/ResourcesPage.js
@@ -97,7 +97,12 @@ function ResourcesPage() {
     const { stage, name } = newTopic;
     if (!stage || !name) return;
     try {
-      await axios.post(`${BACKEND_URL}/api/topics`, { stage, topic: name });
+      const token = localStorage.getItem('token');
+      await axios.post(
+        `${BACKEND_URL}/api/topics`,
+        { stage, topic: name },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
       setTopics((prev) => ({
         ...prev,
         [stage]: { ...(prev[stage] || {}), [name]: [] },
@@ -115,7 +120,12 @@ function ResourcesPage() {
     const { stage, topic, name } = newSubtopic;
     if (!stage || !topic || !name) return;
     try {
-      await axios.post(`${BACKEND_URL}/api/topics`, { stage, topic, subtopic: name });
+      const token = localStorage.getItem('token');
+      await axios.post(
+        `${BACKEND_URL}/api/topics`,
+        { stage, topic, subtopic: name },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
       setTopics((prev) => ({
         ...prev,
         [stage]: {
@@ -134,7 +144,12 @@ function ResourcesPage() {
     e.preventDefault();
     if (!isAdmin) return;
     try {
-      const res = await axios.post(`${BACKEND_URL}/api/resources`, formData);
+      const token = localStorage.getItem('token');
+      const res = await axios.post(
+        `${BACKEND_URL}/api/resources`,
+        formData,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
       setResources((prev) => [...prev, res.data]);
       setFormData({ name: '', link: '', stage: '', topic: '', subtopic: '' });
       setShowForm(false);

--- a/codespace/frontend/src/styles/ProblemsPage.css
+++ b/codespace/frontend/src/styles/ProblemsPage.css
@@ -30,12 +30,9 @@
   height: 100%;
 }
 
-.left-menu select {
+.left-menu .MuiFormControl-root {
   width: 100%;
-  padding: 8px;
   margin-bottom: 15px;
-  border-radius: 6px;
-  border: 1px solid #ccc;
 }
 
 .left-menu button {
@@ -62,7 +59,7 @@
 }
 
 .add-resource-form input,
-.add-resource-form select,
+.add-resource-form .MuiFormControl-root,
 .add-resource-form button {
   width: 100%;
   padding: 8px;
@@ -77,8 +74,9 @@
 }
 
 .add-topic-form input,
+.add-topic-form .MuiFormControl-root,
 .add-topic-form button,
-.add-subtopic-form select,
+.add-subtopic-form .MuiFormControl-root,
 .add-subtopic-form input,
 .add-subtopic-form button {
   width: 100%;

--- a/codespace/frontend/src/styles/ResourcesPage.css
+++ b/codespace/frontend/src/styles/ResourcesPage.css
@@ -33,12 +33,9 @@
   height: 100%;
 }
 
-.left-menu select {
+.left-menu .MuiFormControl-root {
   width: 100%;
-  padding: 8px;
   margin-bottom: 15px;
-  border-radius: 6px;
-  border: 1px solid #ccc;
 }
 
 .left-menu button {
@@ -65,7 +62,7 @@
 }
 
 .add-resource-form input,
-.add-resource-form select,
+.add-resource-form .MuiFormControl-root,
 .add-resource-form button {
   width: 100%;
   padding: 8px;
@@ -80,8 +77,9 @@
 }
 
 .add-topic-form input,
+.add-topic-form .MuiFormControl-root,
 .add-topic-form button,
-.add-subtopic-form select,
+.add-subtopic-form .MuiFormControl-root,
 .add-subtopic-form input,
 .add-subtopic-form button {
   width: 100%;


### PR DESCRIPTION
## Summary
- send auth token when adding resources, problems, topics, and subtopics
- replace resource/problem sidebars with Material UI dropdowns and style updates

## Testing
- `cd codespace/server && npm test`
- `cd codespace/frontend && CI=true npm test` *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*


------
https://chatgpt.com/codex/tasks/task_e_68c2073eb7bc83288ca19fdc0d74dd3d