### PR TITLE
Fix topic upsert failing due to missing id

### DIFF
--- a/codespace/server/model/topicModel.js
+++ b/codespace/server/model/topicModel.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 const { randomUUID } = require('crypto');
 
 const topicSchema = new mongoose.Schema({
-  id: { type: String, default: randomUUID, unique: true },
+  id: { type: String, default: () => randomUUID(), unique: true },
   stage: {
     type: String,
     enum: ['Bronze', 'Silver', 'Gold'],

--- a/codespace/server/routes/problems.js
+++ b/codespace/server/routes/problems.js
@@ -49,8 +49,8 @@ router.post('/', auth, permit('admin', 'superadmin'), async (req, res) => {
 
     await Topic.updateOne(
       { stage, topic, subtopic },
-      { stage, topic, subtopic },
-      { upsert: true }
+      { $set: { stage, topic, subtopic } },
+      { upsert: true, setDefaultsOnInsert: true }
     );
 
     res.status(201).json(problem);
@@ -99,8 +99,8 @@ router.patch('/:id', auth, async (req, res) => {
     ) {
       await Topic.updateOne(
         { stage: problem.stage, topic: problem.topic, subtopic: problem.subtopic },
-        { stage: problem.stage, topic: problem.topic, subtopic: problem.subtopic },
-        { upsert: true }
+        { $set: { stage: problem.stage, topic: problem.topic, subtopic: problem.subtopic } },
+        { upsert: true, setDefaultsOnInsert: true }
       );
     }
 

--- a/codespace/server/routes/resources.js
+++ b/codespace/server/routes/resources.js
@@ -32,8 +32,8 @@ router.post('/', auth, permit('admin', 'superadmin'), async (req, res) => {
 
     await Topic.updateOne(
       { stage, topic, subtopic },
-      { stage, topic, subtopic },
-      { upsert: true }
+      { $set: { stage, topic, subtopic } },
+      { upsert: true, setDefaultsOnInsert: true }
     );
 
     res.status(201).json(resource);
@@ -75,8 +75,8 @@ router.patch('/:id', auth, async (req, res) => {
     ) {
       await Topic.updateOne(
         { stage: resource.stage, topic: resource.topic, subtopic: resource.subtopic },
-        { stage: resource.stage, topic: resource.topic, subtopic: resource.subtopic },
-        { upsert: true }
+        { $set: { stage: resource.stage, topic: resource.topic, subtopic: resource.subtopic } },
+        { upsert: true, setDefaultsOnInsert: true }
       );
     }
 

--- a/codespace/server/routes/topics.js
+++ b/codespace/server/routes/topics.js
@@ -30,8 +30,8 @@ router.post('/', auth, permit('admin', 'superadmin'), async (req, res) => {
     const { stage, topic, subtopic } = req.body;
     await Topic.updateOne(
       { stage, topic, subtopic },
-      { stage, topic, subtopic },
-      { upsert: true }
+      { $set: { stage, topic, subtopic } },
+      { upsert: true, setDefaultsOnInsert: true }
     );
     res.status(201).json({ stage, topic, subtopic });
   } catch (err) {


### PR DESCRIPTION
## Summary
- generate unique ids for topics using randomUUID wrapper
- apply `$set` with `setDefaultsOnInsert` when upserting topics so defaults are created and duplicate key errors are avoided

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2096779e4832881246b76f8795b29