### PR TITLE
Fix verdict display and test case parsing

### DIFF
--- a/codespace/frontend/src/components/CustomProblemPanel.js
+++ b/codespace/frontend/src/components/CustomProblemPanel.js
@@ -17,6 +17,13 @@ const CustomProblemPanel = ({ onAdd, onClose }) => {
   const [cfLink, setCfLink] = useState('');
   const [fetchError, setFetchError] = useState(null);
 
+  const formatIO = (val) =>
+    Array.isArray(val)
+      ? val.join(' ')
+      : typeof val === 'object'
+      ? JSON.stringify(val)
+      : String(val);
+
   function sanitize(statement) {
     let res = "";
     let buffer = "";
@@ -88,8 +95,8 @@ const CustomProblemPanel = ({ onAdd, onClose }) => {
       maxArrayLength: maxLen,
     });
     if (res.data.tests && res.data.tests[0]) {
-      setSampleInput(res.data.tests[0].input);
-      setSampleOutput(res.data.tests[0].output);
+      setSampleInput(formatIO(res.data.tests[0].input));
+      setSampleOutput(formatIO(res.data.tests[0].output));
     }
   };
 
@@ -100,7 +107,12 @@ const CustomProblemPanel = ({ onAdd, onClose }) => {
       maxArrayLength: maxLen,
     });
     if (res.data.tests) {
-      setTests(res.data.tests);
+      setTests(
+        res.data.tests.map((t) => ({
+          input: formatIO(t.input),
+          output: formatIO(t.output),
+        }))
+      );
     }
   };
 

--- a/codespace/frontend/src/components/TextBox.js
+++ b/codespace/frontend/src/components/TextBox.js
@@ -245,8 +245,9 @@ export default function TextBox({socketRef,currentProbId,tests,onCodeChange,room
             const response = await axios.post(submitUrl, requestData, {
                 headers: { Authorization: `Bearer ${token}` }
             });
-            setOutputvalue(response.data);
-            setColor(response.data.trim()==="Accepted" ? 'green' : 'red');
+            const verdict = response.data.trim();
+            setOutputvalue(verdict);
+            setColor(verdict.startsWith('Accepted') ? 'green' : 'red');
         }
         catch(error){
             if (error.response && error.response.status === 401) {

--- a/codespace/server/jobs/submissionWorker.js
+++ b/codespace/server/jobs/submissionWorker.js
@@ -206,6 +206,7 @@ async function submissionWorker(job) {
                         }
                     }
 
+                    verdictData = verdictData.trim();
                     if (verdictData !== 'Accepted') {
                         verdictData = `${verdictData} on test ${i + 1}`;
                         break;


### PR DESCRIPTION
## Summary
- Ensure verdict comparison trims trailing whitespace to avoid false test numbers
- Convert generated test case inputs/outputs to strings when adding problems
- Highlight Accepted submissions in green and failures in red

## Testing
- `npm test` (server)
- `CI=true npm test` (frontend) *(fails: Cannot find module 'unist-util-visit-parents/do-not-use-color')*

------
https://chatgpt.com/codex/tasks/task_e_68c20c9b7e208328afa96de46bf1f123